### PR TITLE
Fix dash characters in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,13 +215,13 @@ sent along with it, encoded as request headers:
 │                  │                                       │                  │
 │   TraceContext   │           Http Request Headers        │   TraceContext   │
 │ ┌──────────────┐ │          ┌───────────────────┐        │ ┌──────────────┐ │
-│ │ TraceId      │ │          │ X─B3─TraceId      │        │ │ TraceId      │ │
+│ │ TraceId      │ │          │ X-B3-TraceId      │        │ │ TraceId      │ │
 │ │              │ │          │                   │        │ │              │ │
-│ │ ParentSpanId │ │ Extract  │ X─B3─ParentSpanId │ Inject │ │ ParentSpanId │ │
+│ │ ParentSpanId │ │ Extract  │ X-B3-ParentSpanId │ Inject │ │ ParentSpanId │ │
 │ │              ├─┼─────────>│                   ├────────┼>│              │ │
-│ │ SpanId       │ │          │ X─B3─SpanId       │        │ │ SpanId       │ │
+│ │ SpanId       │ │          │ X-B3-SpanId       │        │ │ SpanId       │ │
 │ │              │ │          │                   │        │ │              │ │
-│ │ Sampled      │ │          │ X─B3─Sampled      │        │ │ Sampled      │ │
+│ │ Sampled      │ │          │ X-B3-Sampled      │        │ │ Sampled      │ │
 │ └──────────────┘ │          └───────────────────┘        │ └──────────────┘ │
 │                  │                                       │                  │
 └──────────────────┘                                       └──────────────────┘


### PR DESCRIPTION
I just spent a few hours debugging code that wasn't forwarding B3 headers.

Turns out I copy/pasted the headers from the README, which used a non standard dash character that PHP wasn't able to parse.

Hopefully this will prevent other folks to lose time with this as well!