### PR TITLE
Endpoint createFromGlobals should create using an integer port

### DIFF
--- a/src/Zipkin/Endpoint.php
+++ b/src/Zipkin/Endpoint.php
@@ -89,7 +89,7 @@ class Endpoint
             PHP_SAPI,
             array_key_exists('REMOTE_ADDR', $_SERVER) ? $_SERVER['REMOTE_ADDR'] : null,
             null,
-            array_key_exists('REMOTE_PORT', $_SERVER) ? $_SERVER['REMOTE_PORT'] : null
+            array_key_exists('REMOTE_PORT', $_SERVER) ? (int) $_SERVER['REMOTE_PORT'] : null
         );
     }
 


### PR DESCRIPTION
This PR actually just does one minor thing, but it actually preserves compatibility with jaegers' implementation of their Zipkin Gateway. 

Their struct requires and endpoint port to be an integer. Although the create method for the `Endpoint`  is typed correctly, `REMOTE_PORT` is still a string when fetched through `$_SERVER`:

```php
["REMOTE_PORT"]=>
string(5) "51124"
```

Jaeger zipkin struct: https://github.com/jaegertracing/jaeger/blob/50429cb55aee9280e39621a0b5aae3c2afe5d190/cmd/collector/app/zipkin/json.go#L35


I was not sure on how to fit tests for this. Does any of the maintainers have a clue on this?