### PR TITLE
Allow a timeout value to be set on the cURL Call.

### DIFF
--- a/src/Zipkin/Reporters/Http/CurlFactory.php
+++ b/src/Zipkin/Reporters/Http/CurlFactory.php
@@ -50,6 +50,10 @@ final class CurlFactory implements ClientFactory
             }, array_keys($headers), $headers);
             curl_setopt($handle, CURLOPT_HTTPHEADER, $formattedHeaders);
 
+            if (isset($options['timeout'])) {
+                curl_setopt($handle, CURLOPT_TIMEOUT, $options['timeout']);
+            }
+
             if (curl_exec($handle) !== false) {
                 $statusCode = curl_getinfo($handle, CURLINFO_HTTP_CODE);
                 curl_close($handle);


### PR DESCRIPTION
Generally speaking, the Zipkin reporting call should be non-blocking and asynchronous.  But since PHP almost doesn't have either of these properties, it's good to at least be sure that reporting of the Zipkin Trace is not causing a major delay in sampled traces.

Closes #94