### PR TITLE
Fix organization references in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Latest Stable Version](https://poser.pugx.org/openzipkin/zipkin/v/stable)](https://packagist.org/packages/openzipkin/zipkin)
 [![Coverage Status](https://coveralls.io/repos/github/openzipkin/zipkin-php/badge.svg)](https://coveralls.io/github/openzipkin/zipkin-php)
 [![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%205.6-8892BF.svg)](https://php.net/)
-[![Total Downloads](https://poser.pugx.org/jcchavezs/zipkin/downloads)](https://packagist.org/packages/jcchavezs/zipkin)
+[![Total Downloads](https://poser.pugx.org/openzipkin/zipkin/downloads)](https://packagist.org/packages/openzipkin/zipkin)
 [![License](https://img.shields.io/packagist/l/openzipkin/zipkin.svg)](https://github.com/openzipkin/zipkin-php/blob/master/LICENSE)
 
 This is a **production ready** PHP library for Zipkin.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ example, check [this repository](https://github.com/openzipkin/zipkin-php-exampl
 ## Installation
 
 ```bash
-composer require jcchavezs/zipkin
+composer require openzipkin/zipkin
 ```
 
 ## Setup


### PR DESCRIPTION
* Changes installation instructions to go with current version of this package
* Changes downloads badge to use current version of this package

Seems that this may have gotten missed when moving to new organization ( 8f8458b484277c672b0c82b67b27d4f8da52c284 , 8db5b0444cd73d42cfc3070b982e5e3a166398c7 , etc)