### PR TITLE
chore: improves API usability.

### DIFF
--- a/src/Zipkin/NoopSpan.php
+++ b/src/Zipkin/NoopSpan.php
@@ -51,20 +51,22 @@ final class NoopSpan implements Span
      * set its name without lock contention.
      *
      * @param int|null $timestamp
-     * @return void
+     * @return self
      */
-    public function start(?int $timestamp = null): void
+    public function start(?int $timestamp = null): Span
     {
+        return $this;
     }
 
     /**
      * Sets the string name for the logical operation this span represents.
      *
      * @param string $name
-     * @return void
+     * @return self
      */
-    public function setName(string $name): void
+    public function setName(string $name): Span
     {
+        return $this;
     }
 
     /**
@@ -73,10 +75,11 @@ final class NoopSpan implements Span
      * and that plus its duration as "ss".
      *
      * @param string $kind
-     * @return void
+     * @return self
      */
-    public function setKind(string $kind): void
+    public function setKind(string $kind): Span
     {
+        return $this;
     }
 
     /**
@@ -87,10 +90,11 @@ final class NoopSpan implements Span
      * @param string $key Name used to lookup spans, such as "your_app.version". See {@link Zipkin\Tags} for
      * standard ones.
      * @param string $value value, cannot be <code>null</code>.
-     * @return void
+     * @return self
      */
-    public function setTag(string $key, string $value): void
+    public function tag(string $key, string $value): Span
     {
+        return $this;
     }
 
     /**
@@ -98,11 +102,12 @@ final class NoopSpan implements Span
      *
      * @param string $value A short tag indicating the event, like "finagle.retry"
      * @param int $timestamp
-     * @return void
+     * @return self
      * @see Annotations
      */
-    public function annotate(string $value, int $timestamp): void
+    public function annotate(string $value, int $timestamp): Span
     {
+        return $this;
     }
 
     /**
@@ -111,10 +116,11 @@ final class NoopSpan implements Span
      * It is often expensive to derive a remote address: always check {@link #isNoop()} first!
      *
      * @param Endpoint $remoteEndpoint
-     * @return void
+     * @return self
      */
-    public function setRemoteEndpoint(Endpoint $remoteEndpoint): void
+    public function setRemoteEndpoint(Endpoint $remoteEndpoint): Span
     {
+        return $this;
     }
 
     /**
@@ -152,20 +158,6 @@ final class NoopSpan implements Span
      * @return void
      */
     public function flush(): void
-    {
-    }
-
-    /**
-     * Tags give your span context for search, viewing and analysis. For example, a key
-     * "your_app.version" would let you lookup spans by version. A tag {@link Zipkin\Tags\SQL_QUERY}
-     * isn't searchable, but it can help in debugging when viewing a trace.
-     *
-     * @param string $key Name used to lookup spans, such as "your_app.version". See {@link Zipkin\Tags} for
-     * standard ones.
-     * @param string $value value, cannot be <code>null</code>.
-     * @return void
-     */
-    public function tag(string $key, string $value): void
     {
     }
 }

--- a/src/Zipkin/NoopSpan.php
+++ b/src/Zipkin/NoopSpan.php
@@ -87,9 +87,9 @@ final class NoopSpan implements Span
      * "your_app.version" would let you lookup spans by version. A tag {@link Zipkin\Tags\SQL_QUERY}
      * isn't searchable, but it can help in debugging when viewing a trace.
      *
-     * @param string $key Name used to lookup spans, such as "your_app.version". See {@link Zipkin\Tags} for
+     * @param string $key name used to lookup spans, such as "your_app.version". See {@link Zipkin\Tags} for
      * standard ones.
-     * @param string $value value, cannot be <code>null</code>.
+     * @param string $value value
      * @return self
      */
     public function tag(string $key, string $value): Span

--- a/src/Zipkin/Propagation/CurrentTraceContext.php
+++ b/src/Zipkin/Propagation/CurrentTraceContext.php
@@ -38,8 +38,6 @@ final class CurrentTraceContext
 
     /**
      * Returns the current span context in scope or null if there isn't one.
-     *
-     * @return TraceContext|null
      */
     public function getContext(): ?TraceContext
     {

--- a/src/Zipkin/Propagation/TraceContext.php
+++ b/src/Zipkin/Propagation/TraceContext.php
@@ -112,11 +112,7 @@ final class TraceContext implements SamplingFlags
         );
     }
 
-    /**
-     * @param TraceContext $parent
-     * @return TraceContext
-     */
-    public static function createFromParent(TraceContext $parent): self
+    public static function createFromParent(TraceContext $parent): TraceContext
     {
         $nextId = Id\generateNextId();
 
@@ -186,11 +182,7 @@ final class TraceContext implements SamplingFlags
         return $this->parentId;
     }
 
-    /**
-     * @param string $isSampled
-     * @return TraceContext
-     */
-    public function withSampled($isSampled): TraceContext
+    public function withSampled(bool $isSampled): TraceContext
     {
         return new TraceContext(
             $this->traceId,

--- a/src/Zipkin/RealSpan.php
+++ b/src/Zipkin/RealSpan.php
@@ -38,9 +38,9 @@ final class RealSpan implements Span
     }
 
     /**
-     * When true, no recording is done and nothing is reported to zipkin. However, this span should
-     * still be injected into outgoing requests. Use this flag to avoid performing expensive
-     * computation.
+     * When true, no recording is done and nothing is reported to zipkin. However, 
+     * this span should still be injected into outgoing requests. Use this flag to 
+     * avoid performing expensive computation.
      *
      * @return bool
      */
@@ -116,7 +116,7 @@ final class RealSpan implements Span
      *
      * @param string $key Name used to lookup spans, such as "your_app.version". See {@link Zipkin\Tags} for
      * standard ones.
-     * @param string $value, cannot be <code>null</code>.
+     * @param string $value.
      * @return self
      */
     public function tag(string $key, string $value): Span
@@ -162,8 +162,6 @@ final class RealSpan implements Span
 
     /**
      * Throws away the current span without reporting it.
-     *
-     * @return void
      */
     public function abandon(): void
     {
@@ -171,10 +169,9 @@ final class RealSpan implements Span
     }
 
     /**
-     * Like {@link #finish()}, except with a given timestamp in microseconds.
-     *
-     * {@link zipkin.Span#duration Zipkin's span duration} is derived by subtracting the start
-     * timestamp from this, and set when appropriate.
+     * {@link Span#duration Zipkin's span duration} is derived by subtracting the start
+     * timestamp from the provided finish timestamp (using NOW if none provided), and 
+     * set when appropriate.
      *
      * @param int|null $timestamp
      * @return void

--- a/src/Zipkin/RealSpan.php
+++ b/src/Zipkin/RealSpan.php
@@ -32,7 +32,7 @@ final class RealSpan implements Span
      * @param Recorder $recorder
      * @return RealSpan
      */
-    public static function create(TraceContext $context, Recorder $recorder): self
+    public static function create(TraceContext $context, Recorder $recorder): Span
     {
         return new self($context, $recorder);
     }
@@ -64,10 +64,10 @@ final class RealSpan implements Span
      * set its name without lock contention.
      *
      * @param int $timestamp
-     * @return void
+     * @return self
      * @throws \InvalidArgumentException
      */
-    public function start(?int $timestamp = null): void
+    public function start(?int $timestamp = null): Span
     {
         if ($timestamp === null) {
             $timestamp = now();
@@ -80,17 +80,19 @@ final class RealSpan implements Span
         }
 
         $this->recorder->start($this->traceContext, $timestamp);
+        return $this;
     }
 
     /**
      * Sets the string name for the logical operation this span represents.
      *
      * @param string $name
-     * @return void
+     * @return self
      */
-    public function setName(string $name): void
+    public function setName(string $name): Span
     {
         $this->recorder->setName($this->traceContext, $name);
+        return $this;
     }
 
     /**
@@ -99,11 +101,12 @@ final class RealSpan implements Span
      * and that plus its duration as "ss".
      *
      * @param string $kind
-     * @return void
+     * @return self
      */
-    public function setKind(string $kind): void
+    public function setKind(string $kind): Span
     {
         $this->recorder->setKind($this->traceContext, $kind);
+        return $this;
     }
 
     /**
@@ -114,11 +117,12 @@ final class RealSpan implements Span
      * @param string $key Name used to lookup spans, such as "your_app.version". See {@link Zipkin\Tags} for
      * standard ones.
      * @param string $value, cannot be <code>null</code>.
-     * @return void
+     * @return self
      */
-    public function tag(string $key, string $value): void
+    public function tag(string $key, string $value): Span
     {
         $this->recorder->tag($this->traceContext, $key, $value);
+        return $this;
     }
 
     /**
@@ -126,19 +130,20 @@ final class RealSpan implements Span
      *
      * @param string $value A short tag indicating the event, like "finagle.retry"
      * @param int|null $timestamp
-     * @return void
+     * @return self
      * @throws \InvalidArgumentException
      * @see Zipkin\Annotations
      */
-    public function annotate(string $value, ?int $timestamp = null): void
+    public function annotate(string $value, ?int $timestamp = null): Span
     {
-        if (!isValid($timestamp)) {
+        if ($timestamp !== null && !isValid($timestamp)) {
             throw new InvalidArgumentException(
                 sprintf('Valid timestamp represented microtime expected, got \'%s\'', $timestamp)
             );
         }
 
-        $this->recorder->annotate($this->traceContext, $timestamp, $value);
+        $this->recorder->annotate($this->traceContext, $timestamp ?? now(), $value);
+        return $this;
     }
 
     /**
@@ -147,11 +152,12 @@ final class RealSpan implements Span
      * It is often expensive to derive a remote address: always check {@link #isNoop()} first!
      *
      * @param Endpoint $remoteEndpoint
-     * @return void
+     * @return self
      */
-    public function setRemoteEndpoint(Endpoint $remoteEndpoint): void
+    public function setRemoteEndpoint(Endpoint $remoteEndpoint): Span
     {
         $this->recorder->setRemoteEndpoint($this->traceContext, $remoteEndpoint);
+        return $this;
     }
 
     /**

--- a/src/Zipkin/Span.php
+++ b/src/Zipkin/Span.php
@@ -29,17 +29,17 @@ interface Span
      * set its name without lock contention.
      *
      * @param int|null $timestamp
-     * @return void
+     * @return self
      */
-    public function start(?int $timestamp = null): void;
+    public function start(?int $timestamp = null): self;
 
     /**
      * Sets the string name for the logical operation this span represents.
      *
      * @param string $name
-     * @return void
+     * @return self
      */
-    public function setName(string $name): void;
+    public function setName(string $name): self;
 
     /**
      * The kind of span is optional. When set, it affects how a span is reported. For example, if the
@@ -49,9 +49,9 @@ interface Span
      * The value must be strictly one of the ones listed in {@link Kind}.
      *
      * @param string $kind
-     * @return void
+     * @return self
      */
-    public function setKind(string $kind): void;
+    public function setKind(string $kind): self;
 
     /**
      * Tags give your span context for search, viewing and analysis. For example, a key
@@ -61,19 +61,19 @@ interface Span
      * @param string $key Name used to lookup spans, such as "your_app.version". See {@link Zipkin\Tags} for
      * standard ones.
      * @param string $value value, cannot be <code>null</code>.
-     * @return void
+     * @return self
      */
-    public function tag(string $key, string $value): void;
+    public function tag(string $key, string $value): self;
 
     /**
      * Associates an event that explains latency with the current system time.
      *
      * @param string $value A short tag indicating the event, like "finagle.retry"
      * @param int $timestamp
-     * @return void
+     * @return self
      * @see Annotations
      */
-    public function annotate(string $value, int $timestamp): void;
+    public function annotate(string $value, int $timestamp): self;
 
     /**
      * For a client span, this would be the server's address.
@@ -81,9 +81,9 @@ interface Span
      * It is often expensive to derive a remote address: always check {@link #isNoop()} first!
      *
      * @param Endpoint $remoteEndpoint
-     * @return void
+     * @return self
      */
-    public function setRemoteEndpoint(Endpoint $remoteEndpoint): void;
+    public function setRemoteEndpoint(Endpoint $remoteEndpoint): self;
 
     /**
      * Throws away the current span without reporting it.

--- a/src/Zipkin/Span.php
+++ b/src/Zipkin/Span.php
@@ -60,7 +60,7 @@ interface Span
      *
      * @param string $key Name used to lookup spans, such as "your_app.version". See {@link Zipkin\Tags} for
      * standard ones.
-     * @param string $value value, cannot be <code>null</code>.
+     * @param string $value value.
      * @return self
      */
     public function tag(string $key, string $value): self;
@@ -93,10 +93,9 @@ interface Span
     public function abandon(): void;
 
     /**
-     * Like {@link #finish()}, except with a given timestamp in microseconds.
-     *
-     * {@link zipkin.Span#duration Zipkin's span duration} is derived by subtracting the start
-     * timestamp from this, and set when appropriate.
+     * {@link Span#duration Zipkin's span duration} is derived by subtracting the start
+     * timestamp from the provided finish timestamp (using NOW if none provided), and 
+     * set when appropriate.
      *
      * @param int|null $timestamp
      * @return void

--- a/src/Zipkin/Tracer.php
+++ b/src/Zipkin/Tracer.php
@@ -10,6 +10,7 @@ use Zipkin\Propagation\DefaultSamplingFlags;
 use Zipkin\Propagation\SamplingFlags;
 use Zipkin\Propagation\TraceContext;
 use Zipkin\Sampler;
+use InvalidArgumentException;
 
 final class Tracer
 {
@@ -62,9 +63,8 @@ final class Tracer
     }
 
     /**
-     * Creates a new trace. If there is an existing trace, use {@link #newChild(TraceContext)}
-     * instead.
-     *
+     * Creates a new span. If there is an existing parent span, pass it as
+     * "parent" in the options.
      *
      * For example, to sample all requests for a specific url:
      * <pre>{@code
@@ -76,33 +76,77 @@ final class Tracer
      *   } else if (strpos('/static', $uri) !== false) {
      *     $flags = SamplingFlags::createAsNotSampled();
      *   }
-     *   return $this->tracer->newTrace($flags);
+     *   return $this->tracer->startSpan('request', ['parent' => $flags]);
      * }
      * }</pre>
-     *
-     * @param SamplingFlags $samplingFlags
-     * @return Span
      */
-    public function newTrace(SamplingFlags $samplingFlags = null): Span
+    public function startSpan(string $name, array $options = []): Span
     {
-        if ($samplingFlags === null) {
-            $samplingFlags = DefaultSamplingFlags::createAsEmpty();
+        $parent = $options['parent'] ?? null;
+        if (!($parent instanceof TraceContext)) {
+            if ($parent === null || $parent instanceof SamplingFlags) {
+                $parent = $this->newRootContext($parent);
+            } else {
+                throw new InvalidArgumentException(sprintf(
+                    'Invalid type for parent: null, %s or %s expected',
+                    SamplingFlags::class,
+                    TraceContext::class
+                ));
+            }
         }
 
-        return $this->ensureSampled($this->newRootContext($samplingFlags));
+        $span = $this->toSpan($parent);
+
+        $defaultTags = $options['tags'] ?? [];
+        foreach ($defaultTags as $key => $value) {
+            $span->tag($key, (string) $value);
+        }
+
+        if (array_key_exists('remote_endpoint', $options)) {
+            $span->setRemoteEndpoint($options['remote_endpoint']);
+        }
+
+        if (array_key_exists('kind', $options)) {
+            $span->setKind($options['kind']);
+        }
+        
+        return $span->setName($name)->start($options['start_time'] ?? null);
     }
 
     /**
-     * Creates a new span within an existing trace. If there is no existing trace, use {@link
-     * #newTrace()} instead.
+     * This creates a new span based on parameters extracted from an incoming request. This will
+     * always result in a new span. If no trace identifiers were extracted, a span will be created
+     * based on the implicit context in the same manner as {@link #nextSpan()}.
      *
-     * @param TraceContext $parent
-     * @return Span
-     * @throws \RuntimeException
+     * <p>Ex.
+     * <pre>{@code
+     * $extracted = $extractor->extract($headers);
+     * $span = $tracer->startNextSpan($extracted);
+     * }</pre>
+     *
+     * <p><em>Note:</em> Unlike {@link #joinSpan(TraceContext)}, this does not attempt to re-use
+     * extracted span IDs. This means the extracted context (if any) is the parent of the span
+     * returned.
+     *
+     * <p><em>Note:</em> If a context could be extracted from the input, that trace is resumed, not
+     * whatever the {@link #currentSpan()} was. Make sure you re-apply {@link #withSpanInScope(Span)}
+     * so that data is written to the correct trace.
+     *
+     * @throws RuntimeException
      */
-    public function newChild(TraceContext $parent): Span
+    public function startNextSpan(string $name, array $options = []): Span
     {
-        return $this->nextSpan($parent);
+        $parent = $this->currentTraceContext->getContext();
+
+        if ($parent === null) {
+            return $this->startSpan($name, $options);
+        }
+
+        if ($parent instanceof TraceContext) {
+            return $this->startSpan($name, ['parent' => TraceContext::createFromParent($parent)] + $options);
+        }
+
+        throw new RuntimeException('Context or flags for next span is invalid.');
     }
 
     /**
@@ -177,82 +221,29 @@ final class Tracer
     }
 
     /**
-     * This creates a new span based on parameters extracted from an incoming request. This will
-     * always result in a new span. If no trace identifiers were extracted, a span will be created
-     * based on the implicit context in the same manner as {@link #nextSpan()}.
-     *
-     * <p>Ex.
-     * <pre>{@code
-     * $extracted = $extractor->extract($headers);
-     * $span = $tracer->nextSpan($extracted);
-     * }</pre>
-     *
-     * <p><em>Note:</em> Unlike {@link #joinSpan(TraceContext)}, this does not attempt to re-use
-     * extracted span IDs. This means the extracted context (if any) is the parent of the span
-     * returned.
-     *
-     * <p><em>Note:</em> If a context could be extracted from the input, that trace is resumed, not
-     * whatever the {@link #currentSpan()} was. Make sure you re-apply {@link #withSpanInScope(Span)}
-     * so that data is written to the correct trace.
-     *
-     * @param SamplingFlags|TraceContext $contextOrFlags
-     * @return Span
-     * @throws \RuntimeException
-     */
-    public function nextSpan(?SamplingFlags $contextOrFlags = null): Span
-    {
-        if ($contextOrFlags === null) {
-            $parent = $this->currentTraceContext->getContext();
-            return $parent === null ? $this->newTrace() : $this->newChild($parent);
-        }
-
-        if ($contextOrFlags instanceof TraceContext) {
-            return $this->toSpan(TraceContext::createFromParent($contextOrFlags));
-        }
-
-        if ($contextOrFlags instanceof SamplingFlags) {
-            $implicitParent = $this->currentTraceContext->getContext();
-            if ($implicitParent === null) {
-                return $this->toSpan($this->newRootContext($contextOrFlags));
-            }
-        }
-
-        throw new RuntimeException('Context or flags for next span is invalid.');
-    }
-
-    /**
      * @param SamplingFlags|TraceContext $contextOrFlags
      * @return TraceContext
      */
-    private function newRootContext(SamplingFlags $contextOrFlags): TraceContext
+    private function newRootContext(?SamplingFlags $contextOrFlags = null): TraceContext
     {
         $context = TraceContext::createAsRoot($contextOrFlags, $this->usesTraceId128bits);
+        return $this->ensureSampled($context);
+    }
 
+    /**
+     * @param TraceContext $context
+     */
+    private function ensureSampled(TraceContext $context): TraceContext
+    {
         if ($context->isSampled() === null) {
-            $context = $context->withSampled($this->sampler->isSampled($context->getTraceId()));
+            return $context->withSampled($this->sampler->isSampled($context->getTraceId()));
         }
 
         return $context;
     }
 
     /**
-     * @param TraceContext $context
-     * @return Span
-     */
-    private function ensureSampled(TraceContext $context): Span
-    {
-        if ($context->isSampled() === null) {
-            $context = $context->withSampled($this->sampler->isSampled($context->getTraceId()));
-        }
-
-        return $this->toSpan($context);
-    }
-
-    /**
      * Converts the context as-is to a Span object
-     *
-     * @param TraceContext $context
-     * @return Span
      */
     private function toSpan(TraceContext $context): Span
     {

--- a/tests/Unit/Reporters/InMemoryTest.php
+++ b/tests/Unit/Reporters/InMemoryTest.php
@@ -17,9 +17,7 @@ final class InMemoryTest extends TestCase
             ->havingReporter($reporter)
             ->build();
 
-        $span = $tracing->getTracer()->nextSpan();
-        $span->start();
-        $span->finish();
+        $tracing->getTracer()->startNextSpan('name')->finish();
 
         $tracing->getTracer()->flush();
         $flushedSpans = $reporter->flush();


### PR DESCRIPTION
This PR breaks the API (already broken when we moved to PHP 7) and notably we changed the way we build spans:

From
```php
$span = $tracer->newChild($context);
$span->setName('encode');
$span->start(1554988060000);
try {
  doSomethingExpensive();
} finally {
  $span->finish();
}
```

to 

```php
$span = $tracer->startSpan('encode', ['parent' => $context, 'start_time' => 1554988060000]);
try {
  doSomethingExpensive();
} finally {
  $span->finish();
}
```

or if we want to create a child on the current one:

```php
$span = $tracer->startNextSpan('encode', ['start_time' => 1554988060000]);
try {
  doSomethingExpensive();
} finally {
  $span->finish();
}
```

This API is inspired in brave (which zipkin PHP v1 was based on) and zipkin-go which has many usability tweaks. Changes are:

- Spans are meant to be started instead of being created and then started (like zipkin-go does)
- Span methods are fluent.

Ping @adriancole @basvanbeek @ghermeto @telemmaite @anensshiya-govinthas-ck