### PR TITLE
fix if endpoint is null, than service name is invalid

### DIFF
--- a/src/Zipkin/TracingBuilder.php
+++ b/src/Zipkin/TracingBuilder.php
@@ -152,7 +152,7 @@ class TracingBuilder
         if ($localEndpoint === null) {
             $localEndpoint = Endpoint::createFromGlobals();
             if ($this->localServiceName !== null) {
-                $localEndpoint->withServiceName($this->localServiceName);
+                $localEndpoint = $localEndpoint->withServiceName($this->localServiceName);
             }
         }
 


### PR DESCRIPTION
`Endpoint::withServiceName` will return a new instance of Endpoint, so when endpoint is null, service name is invalid.