### PR TITLE
chore: removes static constructors when unnecessary.

### DIFF
--- a/src/Zipkin/NoopSpan.php
+++ b/src/Zipkin/NoopSpan.php
@@ -13,18 +13,9 @@ final class NoopSpan implements Span
      */
     private $context;
 
-    private function __construct(TraceContext $context)
+    public function __construct(TraceContext $context)
     {
         $this->context = $context;
-    }
-
-    /**
-     * @param TraceContext $context
-     * @return NoopSpan
-     */
-    public static function create(TraceContext $context): self
-    {
-        return new self($context);
     }
 
     /**
@@ -89,7 +80,7 @@ final class NoopSpan implements Span
      *
      * @param string $key Name used to lookup spans, such as "your_app.version". See {@link Zipkin\Tags} for
      * standard ones.
-     * @param string $value value, cannot be <code>null</code>.
+     * @param string $value
      * @return void
      */
     public function setTag(string $key, string $value): void
@@ -165,7 +156,7 @@ final class NoopSpan implements Span
      *
      * @param string $key Name used to lookup spans, such as "your_app.version". See {@link Zipkin\Tags} for
      * standard ones.
-     * @param string $value value, cannot be <code>null</code>.
+     * @param string $value
      * @return void
      */
     public function tag(string $key, string $value): void

--- a/src/Zipkin/Propagation/CurrentTraceContext.php
+++ b/src/Zipkin/Propagation/CurrentTraceContext.php
@@ -23,20 +23,9 @@ final class CurrentTraceContext
      */
     private $context;
 
-    private function __construct(TraceContext $currentContext = null)
+    public function __construct(TraceContext $currentContext = null)
     {
         $this->context = $currentContext;
-    }
-
-    /**
-     * Creates a current trace context controller. If there is no context, and consequently no span, it holds null.
-     *
-     * @param TraceContext|null $currentContext
-     * @return CurrentTraceContext
-     */
-    public static function create(TraceContext $currentContext = null): self
-    {
-        return new self($currentContext);
     }
 
     /**

--- a/src/Zipkin/RealSpan.php
+++ b/src/Zipkin/RealSpan.php
@@ -21,20 +21,10 @@ final class RealSpan implements Span
      */
     private $traceContext;
 
-    private function __construct(TraceContext $context, Recorder $recorder)
+    public function __construct(TraceContext $context, Recorder $recorder)
     {
         $this->traceContext = $context;
         $this->recorder = $recorder;
-    }
-
-    /**
-     * @param TraceContext $context
-     * @param Recorder $recorder
-     * @return RealSpan
-     */
-    public static function create(TraceContext $context, Recorder $recorder): self
-    {
-        return new self($context, $recorder);
     }
 
     /**

--- a/src/Zipkin/Recorder.php
+++ b/src/Zipkin/Recorder.php
@@ -43,7 +43,7 @@ class Recorder
         $this->endpoint = $endpoint;
         $this->reporter = $reporter;
         $this->noop = $isNoop;
-        $this->spanMap = SpanMap::create();
+        $this->spanMap = new SpanMap;
     }
 
     public static function createAsNoop(): self

--- a/src/Zipkin/Recording/SpanMap.php
+++ b/src/Zipkin/Recording/SpanMap.php
@@ -15,14 +15,6 @@ final class SpanMap
     private $map = [];
 
     /**
-     * @return SpanMap
-     */
-    public static function create()
-    {
-        return new self();
-    }
-
-    /**
      * @param TraceContext $context
      * @return Span|null
      */

--- a/src/Zipkin/Reporters/Http/CurlFactory.php
+++ b/src/Zipkin/Reporters/Http/CurlFactory.php
@@ -51,7 +51,7 @@ final class CurlFactory implements ClientFactory
                 'Content-Type' => 'application/json',
                 'Content-Length' => \strlen($payload),
             ];
-            $additionalHeaders = $options['headers'] ?: [];
+            $additionalHeaders = $options['headers'] ?? [];
             $headers = \array_merge($additionalHeaders, $requiredHeaders);
             $formattedHeaders = \array_map(function ($key, $value) {
                 return $key . ': ' . $value;

--- a/src/Zipkin/Span.php
+++ b/src/Zipkin/Span.php
@@ -60,7 +60,7 @@ interface Span
      *
      * @param string $key Name used to lookup spans, such as "your_app.version". See {@link Zipkin\Tags} for
      * standard ones.
-     * @param string $value value, cannot be <code>null</code>.
+     * @param string $value
      * @return void
      */
     public function tag(string $key, string $value): void;

--- a/src/Zipkin/Tracer.php
+++ b/src/Zipkin/Tracer.php
@@ -257,9 +257,9 @@ final class Tracer
     private function toSpan(TraceContext $context): Span
     {
         if (!$this->isNoop && $context->isSampled()) {
-            return RealSpan::create($context, $this->recorder);
+            return new RealSpan($context, $this->recorder);
         }
 
-        return NoopSpan::create($context);
+        return new NoopSpan($context);
     }
 }

--- a/src/Zipkin/TracingBuilder.php
+++ b/src/Zipkin/TracingBuilder.php
@@ -160,7 +160,7 @@ class TracingBuilder
 
         $reporter = $this->reporter ?: new Log(new NullLogger());
         $sampler = $this->sampler ?: BinarySampler::createAsNeverSample();
-        $currentTraceContext = $this->currentTraceContext ?: CurrentTraceContext::create();
+        $currentTraceContext = $this->currentTraceContext ?: new CurrentTraceContext;
 
         return new DefaultTracing(
             $localEndpoint,

--- a/tests/Unit/DefaultTracingTest.php
+++ b/tests/Unit/DefaultTracingTest.php
@@ -26,7 +26,7 @@ final class DefaultTracingTest extends TestCase
             $reporter,
             $sampler,
             false,
-            CurrentTraceContext::create(),
+            new CurrentTraceContext,
             $isNoop
         );
 

--- a/tests/Unit/NoopSpanTest.php
+++ b/tests/Unit/NoopSpanTest.php
@@ -11,7 +11,7 @@ final class NoopSpanTest extends TestCase
     public function testCreateNoopSpanSuccess()
     {
         $context = TraceContext::createAsRoot();
-        $span = NoopSpan::create($context);
+        $span = new NoopSpan($context);
         $this->assertTrue($span instanceof NoopSpan);
     }
 }

--- a/tests/Unit/Propagation/CurrentTraceContextTest.php
+++ b/tests/Unit/Propagation/CurrentTraceContextTest.php
@@ -11,7 +11,7 @@ final class CurrentTraceContextTest extends TestCase
     public function testCurrentTraceContextIsCreated()
     {
         $context = TraceContext::createAsRoot();
-        $currentTraceContext = CurrentTraceContext::create($context);
+        $currentTraceContext = new CurrentTraceContext($context);
         $this->assertEquals($context, $currentTraceContext->getContext());
     }
 
@@ -20,7 +20,7 @@ final class CurrentTraceContextTest extends TestCase
      */
     public function testNewScopeSuccess($context1)
     {
-        $currentTraceContext = CurrentTraceContext::create($context1);
+        $currentTraceContext = new CurrentTraceContext($context1);
         $context2 = TraceContext::createAsRoot();
 
         $scopeCloser = $currentTraceContext->createScopeAndRetrieveItsCloser($context2);

--- a/tests/Unit/RealSpanTest.php
+++ b/tests/Unit/RealSpanTest.php
@@ -21,7 +21,7 @@ final class RealSpanTest extends TestCase
     {
         $context = TraceContext::createAsRoot();
         $recorder = $this->prophesize(Recorder::class);
-        $span = RealSpan::create($context, $recorder->reveal());
+        $span = new RealSpan($context, $recorder->reveal());
         $this->assertEquals($context, $span->getContext());
     }
 
@@ -30,7 +30,7 @@ final class RealSpanTest extends TestCase
         $context = TraceContext::createAsRoot();
         $recorder = $this->prophesize(Recorder::class);
         $recorder->start($context, self::TEST_START_TIMESTAMP)->shouldBeCalled();
-        $span = RealSpan::create($context, $recorder->reveal());
+        $span = new RealSpan($context, $recorder->reveal());
         $span->start(self::TEST_START_TIMESTAMP);
     }
 
@@ -39,7 +39,7 @@ final class RealSpanTest extends TestCase
         $context = TraceContext::createAsRoot();
         $recorder = $this->prophesize(Recorder::class);
         $recorder->setName($context, self::TEST_NAME)->shouldBeCalled();
-        $span = RealSpan::create($context, $recorder->reveal());
+        $span = new RealSpan($context, $recorder->reveal());
         $span->setName(self::TEST_NAME);
     }
 
@@ -48,7 +48,7 @@ final class RealSpanTest extends TestCase
         $context = TraceContext::createAsRoot();
         $recorder = $this->prophesize(Recorder::class);
         $recorder->setKind($context, self::TEST_KIND)->shouldBeCalled();
-        $span = RealSpan::create($context, $recorder->reveal());
+        $span = new RealSpan($context, $recorder->reveal());
         $span->setKind(self::TEST_KIND);
     }
 
@@ -58,7 +58,7 @@ final class RealSpanTest extends TestCase
         $remoteEndpoint = Endpoint::createAsEmpty();
         $recorder = $this->prophesize(Recorder::class);
         $recorder->setRemoteEndpoint($context, $remoteEndpoint)->shouldBeCalled();
-        $span = RealSpan::create($context, $recorder->reveal());
+        $span = new RealSpan($context, $recorder->reveal());
         $span->setRemoteEndpoint($remoteEndpoint);
     }
 
@@ -69,7 +69,7 @@ final class RealSpanTest extends TestCase
         $context = TraceContext::createAsRoot();
         $recorder = $this->prophesize(Recorder::class);
         $recorder->annotate($context, $timestamp, $value)->shouldBeCalled();
-        $span = RealSpan::create($context, $recorder->reveal());
+        $span = new RealSpan($context, $recorder->reveal());
         $span->annotate($value, $timestamp);
     }
 
@@ -81,7 +81,7 @@ final class RealSpanTest extends TestCase
         $context = TraceContext::createAsRoot();
         $recorder = $this->prophesize(Recorder::class);
         $recorder->annotate($context, $timestamp, $value)->shouldNotBeCalled();
-        $span = RealSpan::create($context, $recorder->reveal());
+        $span = new RealSpan($context, $recorder->reveal());
         $this->expectException(InvalidArgumentException::class);
         $span->annotate($value, $timestamp);
     }
@@ -91,7 +91,7 @@ final class RealSpanTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $context = TraceContext::createAsRoot();
         $recorder = $this->prophesize(Recorder::class);
-        $span = RealSpan::create($context, $recorder->reveal());
+        $span = new RealSpan($context, $recorder->reveal());
         $span->start(-1);
     }
 }

--- a/tests/Unit/Recording/SpanMapTest.php
+++ b/tests/Unit/Recording/SpanMapTest.php
@@ -13,13 +13,13 @@ final class SpanMapTest extends TestCase
 {
     public function testCreateASpanMapSuccess()
     {
-        $spanMap = SpanMap::create();
+        $spanMap = new SpanMap;
         $this->assertInstanceOf(SpanMap::class, $spanMap);
     }
 
     public function testGetReturnsOrCreateOnNonExistingSpan()
     {
-        $spanMap = SpanMap::create();
+        $spanMap = new SpanMap;
         $context = TraceContext::createAsRoot(DefaultSamplingFlags::createAsEmpty());
         $endpoint = Endpoint::createAsEmpty();
         $span = $spanMap->getOrCreate($context, $endpoint);
@@ -28,14 +28,14 @@ final class SpanMapTest extends TestCase
 
     public function testGetReturnsNullOnNonExistingSpan()
     {
-        $spanMap = SpanMap::create();
+        $spanMap = new SpanMap;
         $context = TraceContext::createAsRoot(DefaultSamplingFlags::createAsEmpty());
         $this->assertNull($spanMap->get($context));
     }
 
     public function testGetReturnsDifferentObjects()
     {
-        $spanMap = SpanMap::create();
+        $spanMap = new SpanMap;
         $endpoint = Endpoint::createAsEmpty();
         $rootSpan = TraceContext::createAsRoot(DefaultSamplingFlags::createAsEmpty());
         $recordedSpans = [];
@@ -52,7 +52,7 @@ final class SpanMapTest extends TestCase
 
     public function testRemoveReturnsEmptyAfterRemoval()
     {
-        $spanMap = SpanMap::create();
+        $spanMap = new SpanMap;
         $context = TraceContext::createAsRoot(DefaultSamplingFlags::createAsEmpty());
         $endpoint = Endpoint::createAsEmpty();
         $spanMap->getOrCreate($context, $endpoint);
@@ -62,7 +62,7 @@ final class SpanMapTest extends TestCase
 
     public function testRemoveAllReturnsEmptyAfterRemoval()
     {
-        $spanMap = SpanMap::create();
+        $spanMap = new SpanMap;
         $contexts = [];
         $numberOfContexts = 3;
 

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -37,7 +37,7 @@ final class TracerTest extends TestCase
     {
         $this->reporter = $this->prophesize(Reporter::class);
         $this->sampler = $this->prophesize(Sampler::class);
-        $this->currentTracerContext = CurrentTraceContext::create();
+        $this->currentTracerContext = new CurrentTraceContext;
     }
 
     public function testNewTraceSuccess()
@@ -69,7 +69,7 @@ final class TracerTest extends TestCase
             $this->reporter->reveal(),
             $this->sampler->reveal(),
             true,
-            CurrentTraceContext::create(),
+            new CurrentTraceContext,
             false
         );
 
@@ -294,7 +294,7 @@ final class TracerTest extends TestCase
             $this->reporter->reveal(),
             BinarySampler::createAsNeverSample(),
             false,
-            CurrentTraceContext::create(),
+            new CurrentTraceContext,
             false
         );
 
@@ -307,7 +307,7 @@ final class TracerTest extends TestCase
     {
         return [
             [null],
-            [NoopSpan::create(TraceContext::createAsRoot())]
+            [new NoopSpan(TraceContext::createAsRoot())]
         ];
     }
 }

--- a/tests/Unit/TracingBuilderTest.php
+++ b/tests/Unit/TracingBuilderTest.php
@@ -30,7 +30,7 @@ final class TracingBuilderTest extends TestCase
         $reporter = new Noop();
         $sampler = BinarySampler::createAsAlwaysSample();
         $usesTraceId128bits = $this->randomBool();
-        $currentTraceContext = CurrentTraceContext::create();
+        $currentTraceContext = new CurrentTraceContext;
 
         $tracing = TracingBuilder::create()
             ->havingLocalServiceName(self::SERVICE_NAME)


### PR DESCRIPTION
One point people makes is usually the fact that we use static constructors in cases where it merely calls the constructor. This PR gets rid of those constructors.