### PR TITLE
chore: makes lookup for Map getter to be case insensitive (#137).

### DIFF
--- a/src/Zipkin/Propagation/Map.php
+++ b/src/Zipkin/Propagation/Map.php
@@ -12,6 +12,13 @@ final class Map implements Getter, Setter
 {
     /**
      * {@inheritdoc}
+     *
+     * If the carrier is an array, the lookup is case insensitive, this is
+     * mainly because Map getter is commonly used for those cases where the
+     * HTTP framework does not follow the PSR request/response objects (e.g.
+     * Symfony) and thus the header bag should be treated as a map. ArrayAccess
+     * can't be case insensitive because we can not know the keys on beforehand.
+     *
      * @param array|ArrayAccess $carrier
      */
     public function get($carrier, string $key): ?string
@@ -23,7 +30,12 @@ final class Map implements Getter, Setter
         }
 
         if (\is_array($carrier)) {
-            return \array_key_exists($lKey, $carrier) ? $carrier[$lKey] : null;
+            if (empty($carrier)) {
+                return null;
+            }
+
+            $lcCarrier = \array_change_key_case($carrier, \CASE_LOWER);
+            return \array_key_exists($lKey, $lcCarrier) ? $lcCarrier[$lKey] : null;
         }
 
         throw InvalidPropagationCarrier::forCarrier($carrier);
@@ -39,6 +51,8 @@ final class Map implements Getter, Setter
             throw InvalidPropagationKey::forEmptyKey();
         }
 
+        // Lowercasing the key was a first attempt to be compatible with the
+        // getter when using the Map getter for HTTP headers.
         $lKey = \strtolower($key);
 
         if ($carrier instanceof ArrayAccess || \is_array($carrier)) {

--- a/tests/Unit/Propagation/MapTest.php
+++ b/tests/Unit/Propagation/MapTest.php
@@ -12,6 +12,7 @@ use Zipkin\Propagation\Map;
 final class MapTest extends TestCase
 {
     const TEST_KEY = 'test_key';
+    const TEST_KEY_INSENSITIVE = 'tEsT_KEy';
     const TEST_VALUE = 'test_value';
     const TEST_INVALID_KEY = 1;
     const TEST_EMPTY_KEY = '';
@@ -30,6 +31,22 @@ final class MapTest extends TestCase
         $map = new Map();
         $value = $map->get($carrier, self::TEST_KEY);
         $this->assertEquals(self::TEST_VALUE, $value);
+    }
+
+    public function testGetFromMapCaseInsensitiveSuccess()
+    {
+        $carrier = [self::TEST_KEY_INSENSITIVE => self::TEST_VALUE];
+        $map = new Map();
+        $value = $map->get($carrier, self::TEST_KEY);
+        $this->assertEquals(self::TEST_VALUE, $value);
+    }
+
+    public function testGetFromMapCaseInsensitiveReturnsNull()
+    {
+        $carrier = new ArrayObject([self::TEST_KEY_INSENSITIVE => self::TEST_VALUE]);
+        $map = new Map();
+        $value = $map->get($carrier, self::TEST_KEY);
+        $this->assertNull($value);
     }
 
     public function testPutToMapFailsDueToEmptyKey()


### PR DESCRIPTION
This applies the same fixes from https://github.com/openzipkin/zipkin-php/pull/139 in master.