### PR TITLE
Adds span customizer

### DIFF
--- a/src/Zipkin/NoopSpan.php
+++ b/src/Zipkin/NoopSpan.php
@@ -83,7 +83,7 @@ final class NoopSpan implements Span
      * @param string $value
      * @return void
      */
-    public function setTag(string $key, string $value): void
+    public function tag(string $key, string $value): void
     {
     }
 
@@ -146,20 +146,6 @@ final class NoopSpan implements Span
      * @return void
      */
     public function flush(): void
-    {
-    }
-
-    /**
-     * Tags give your span context for search, viewing and analysis. For example, a key
-     * "your_app.version" would let you lookup spans by version. A tag {@link Zipkin\Tags\SQL_QUERY}
-     * isn't searchable, but it can help in debugging when viewing a trace.
-     *
-     * @param string $key Name used to lookup spans, such as "your_app.version". See {@link Zipkin\Tags} for
-     * standard ones.
-     * @param string $value
-     * @return void
-     */
-    public function tag(string $key, string $value): void
     {
     }
 }

--- a/src/Zipkin/NoopSpanCustomizer.php
+++ b/src/Zipkin/NoopSpanCustomizer.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zipkin;
+
+final class NoopSpanCustomizer implements SpanCustomizer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function setName(string $name): void
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function tag(string $key, string $value): void
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function annotate(string $value, int $timestamp = null): void
+    {
+    }
+}

--- a/src/Zipkin/RealSpan.php
+++ b/src/Zipkin/RealSpan.php
@@ -99,7 +99,7 @@ final class RealSpan implements Span
      *
      * @param string $key Name used to lookup spans, such as "your_app.version". See {@link Zipkin\Tags} for
      * standard ones.
-     * @param string $value, cannot be <code>null</code>.
+     * @param string $value.
      * @return void
      */
     public function tag(string $key, string $value): void

--- a/src/Zipkin/SpanCustomizer.php
+++ b/src/Zipkin/SpanCustomizer.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zipkin;
+
+/**
+ * Simple interface users can customize a span with. For example, this can add custom tags useful in
+ * looking up spans.
+ *
+ * <p>This type is safer to expose directly to users than {@link Span}, as it has no hooks that
+ * can affect the span lifecycle.
+ */
+interface SpanCustomizer
+{
+    /**
+     * Sets the string name for the logical operation this span represents.
+     *
+     * @param string $name
+     * @return void
+     */
+    public function setName(string $name): void;
+
+    /**
+     * Tags give your span context for search, viewing and analysis. For example, a key
+     * "your_app.version" would let you lookup spans by version. A tag {@link Zipkin\Tags\SQL_QUERY}
+     * isn't searchable, but it can help in debugging when viewing a trace.
+     *
+     * @param string $key Name used to lookup spans, such as "your_app.version". See {@link Zipkin\Tags} for
+     * standard ones.
+     * @param string $value value.
+     * @return void
+     */
+    public function tag(string $key, string $value): void;
+
+    /**
+     * Associates an event that explains latency with the current system time.
+     *
+     * @param string $value A short tag indicating the event, like "finagle.retry"
+     * @param int $timestamp
+     * @return void
+     * @see Annotations
+     */
+    public function annotate(string $value, int $timestamp = null): void;
+}

--- a/src/Zipkin/SpanCustomizerShield.php
+++ b/src/Zipkin/SpanCustomizerShield.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zipkin;
+
+final class SpanCustomizerShield implements SpanCustomizer
+{
+    /**
+     * @var Span
+     */
+    private $delegate;
+
+    /**
+     * @var bool
+     */
+    private $isNotNoop = false;
+
+    public function __construct(Span $span)
+    {
+        if (!$span->isNoop()) {
+            $this->delegate = $span;
+            $this->isNotNoop = true;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setName(string $name): void
+    {
+        if ($this->isNotNoop) {
+            $this->delegate->setName($name);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function tag(string $key, string $value): void
+    {
+        if ($this->isNotNoop) {
+            $this->delegate->tag($key, $value);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function annotate(string $value, int $timestamp = null): void
+    {
+        if ($this->isNotNoop) {
+            $this->delegate->annotate($value, $timestamp);
+        }
+    }
+}

--- a/src/Zipkin/SpanCustomizerShield.php
+++ b/src/Zipkin/SpanCustomizerShield.php
@@ -18,6 +18,7 @@ final class SpanCustomizerShield implements SpanCustomizer
 
     public function __construct(Span $span)
     {
+        // If NOOP span we don't want to do the actual calls.
         if (!$span->isNoop()) {
             $this->delegate = $span;
             $this->isNotNoop = true;

--- a/tests/Unit/NoopSpan.php
+++ b/tests/Unit/NoopSpan.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace ZipkinTests\Unit;
+
+use Zipkin\Endpoint;
+use Zipkin\Propagation\TraceContext;
+use PHPUnit\Framework\TestCase;
+
+trait NoopSpan
+{
+    /**
+     * @var TestCase
+     */
+    private $test;
+
+    /**
+     * @var TraceContext
+     */
+    private $context;
+
+    public function __construct(TestCase $test)
+    {
+        $this->test = $test;
+        $this->context = TraceContext::createAsRoot();
+    }
+
+    public function isNoop(): bool
+    {
+        return true;
+    }
+
+    public function getContext(): TraceContext
+    {
+        return $this->context;
+    }
+
+    public function start(int $timestamp = null): void
+    {
+    }
+
+    public function setName(string $name): void
+    {
+        $this->test->assertEquals(SpanCustomizerShieldTest::TEST_NAME, $name);
+    }
+
+    public function setKind(string $kind): void
+    {
+    }
+    public function tag(string $key, string $value): void
+    {
+        $this->test->assertEquals(SpanCustomizerShieldTest::TEST_TAG_KEY, $key);
+        $this->test->assertEquals(SpanCustomizerShieldTest::TEST_TAG_VALUE, $value);
+    }
+    public function annotate(string $value, int $timestamp = null): void
+    {
+        $this->test->assertEquals(SpanCustomizerShieldTest::TEST_ANNOTATION_VALUE, $value);
+    }
+    public function setRemoteEndpoint(Endpoint $remoteEndpoint): void
+    {
+    }
+    public function abandon(): void
+    {
+    }
+    public function finish(int $timestamp = null): void
+    {
+    }
+    public function flush(): void
+    {
+    }
+};

--- a/tests/Unit/SpanCustomizerShieldNoopSpan.php
+++ b/tests/Unit/SpanCustomizerShieldNoopSpan.php
@@ -6,7 +6,7 @@ use Zipkin\Endpoint;
 use Zipkin\Propagation\TraceContext;
 use PHPUnit\Framework\TestCase;
 
-trait NoopSpan
+trait SpanCustomizerShieldNoopSpan
 {
     /**
      * @var TestCase
@@ -38,33 +38,23 @@ trait NoopSpan
     {
     }
 
-    public function setName(string $name): void
-    {
-        $this->test->assertEquals(SpanCustomizerShieldTest::TEST_NAME, $name);
-    }
-
     public function setKind(string $kind): void
     {
     }
-    public function tag(string $key, string $value): void
-    {
-        $this->test->assertEquals(SpanCustomizerShieldTest::TEST_TAG_KEY, $key);
-        $this->test->assertEquals(SpanCustomizerShieldTest::TEST_TAG_VALUE, $value);
-    }
-    public function annotate(string $value, int $timestamp = null): void
-    {
-        $this->test->assertEquals(SpanCustomizerShieldTest::TEST_ANNOTATION_VALUE, $value);
-    }
+
     public function setRemoteEndpoint(Endpoint $remoteEndpoint): void
     {
     }
+
     public function abandon(): void
     {
     }
+
     public function finish(int $timestamp = null): void
     {
     }
+
     public function flush(): void
     {
     }
-};
+}

--- a/tests/Unit/SpanCustomizerShieldTest.php
+++ b/tests/Unit/SpanCustomizerShieldTest.php
@@ -16,7 +16,7 @@ final class SpanCustomizerShieldTest extends TestCase
     public function testAttributesAreSetAndMethodAreCalled()
     {
         $span = new class($this) implements Span {
-            use NoopSpan;
+            use SpanCustomizerShieldNoopSpan;
 
             public function isNoop(): bool
             {
@@ -49,21 +49,21 @@ final class SpanCustomizerShieldTest extends TestCase
     public function testMethodsAreNotCalledOnNoop()
     {
         $span = new class($this) implements Span {
-            use NoopSpan;
+            use SpanCustomizerShieldNoopSpan;
 
             public function setName(string $name): void
             {
-                $this->test->fail("should not be called");
+                $this->test->fail("setName should not be called");
             }
 
             public function tag(string $key, string $value): void
             {
-                $this->test->fail("should not be called");
+                $this->test->fail("tag should not be called");
             }
 
             public function annotate(string $value, int $timestamp = null): void
             {
-                $this->test->fail("should not be called");
+                $this->test->fail("annotate should not be called");
             }
         };
 

--- a/tests/Unit/SpanCustomizerShieldTest.php
+++ b/tests/Unit/SpanCustomizerShieldTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace ZipkinTests\Unit;
+
+use Zipkin\Span;
+use PHPUnit\Framework\TestCase;
+use Zipkin\SpanCustomizerShield;
+
+final class SpanCustomizerShieldTest extends TestCase
+{
+    const TEST_NAME = 'name';
+    const TEST_TAG_KEY = 'key';
+    const TEST_TAG_VALUE = 'value';
+    const TEST_ANNOTATION_VALUE = 'annotation';
+
+    public function testAttributesAreSetAndMethodAreCalled()
+    {
+        $span = new class($this) implements Span {
+            use NoopSpan;
+
+            public function isNoop(): bool
+            {
+                return false;
+            }
+
+            public function setName(string $name): void
+            {
+                $this->test->assertEquals(SpanCustomizerShieldTest::TEST_NAME, $name);
+            }
+
+            public function tag(string $key, string $value): void
+            {
+                $this->test->assertEquals(SpanCustomizerShieldTest::TEST_TAG_KEY, $key);
+                $this->test->assertEquals(SpanCustomizerShieldTest::TEST_TAG_VALUE, $value);
+            }
+
+            public function annotate(string $value, int $timestamp = null): void
+            {
+                $this->test->assertEquals(SpanCustomizerShieldTest::TEST_ANNOTATION_VALUE, $value);
+            }
+        };
+
+        $spanCustomizer = new SpanCustomizerShield($span);
+        $spanCustomizer->setName(self::TEST_NAME);
+        $spanCustomizer->tag(self::TEST_TAG_KEY, self::TEST_TAG_VALUE);
+        $spanCustomizer->annotate(self::TEST_ANNOTATION_VALUE);
+    }
+
+    public function testMethodsAreNotCalledOnNoop()
+    {
+        $span = new class($this) implements Span {
+            use NoopSpan;
+
+            public function setName(string $name): void
+            {
+                $this->test->fail("should not be called");
+            }
+
+            public function tag(string $key, string $value): void
+            {
+                $this->test->fail("should not be called");
+            }
+
+            public function annotate(string $value, int $timestamp = null): void
+            {
+                $this->test->fail("should not be called");
+            }
+        };
+
+        $spanCustomizer = new SpanCustomizerShield($span);
+        $spanCustomizer->setName(self::TEST_NAME);
+        $spanCustomizer->tag(self::TEST_TAG_KEY, self::TEST_TAG_VALUE);
+        $spanCustomizer->annotate(self::TEST_ANNOTATION_VALUE);
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
This PR introduces the new concept of `SpanCustomizer` which is a port from brave and it is a needed abstractions for upcoming improvements to the library: inSpan and HTTP client/server PSR implementation.