### PR TITLE
chore: fixes retrocompatibility of the HTTP reporter constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $endpoint = Endpoint::create('my_service');
 $logger = new \Monolog\Logger('log');
 $logger->pushHandler(new \Monolog\Handler\ErrorLogHandler());
 
-$reporter = new Http(null, ['endpoint_url' => 'http://myzipkin:9411/api/v2/spans']);
+$reporter = new Http(['endpoint_url' => 'http://myzipkin:9411/api/v2/spans']);
 $sampler = BinarySampler::createAsAlwaysSample();
 $tracing = TracingBuilder::create()
     ->havingLocalEndpoint($endpoint)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $endpoint = Endpoint::create('my_service');
 $logger = new \Monolog\Logger('log');
 $logger->pushHandler(new \Monolog\Handler\ErrorLogHandler());
 
-$reporter = new Http(['endpoint_url' => 'http://myzipkin:9411/api/v2/spans']);
+$reporter = new Http(null, ['endpoint_url' => 'http://myzipkin:9411/api/v2/spans']);
 $sampler = BinarySampler::createAsAlwaysSample();
 $tracing = TracingBuilder::create()
     ->havingLocalEndpoint($endpoint)

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,6 @@
 parameters:
+	checkGenericClassInNonGenericObjectType: false
+	treatPhpDocTypesAsCertain: false
 	autoload_files:
 		- vendor/autoload.php
 	checkMissingIterableValueType: false
@@ -11,3 +13,11 @@ parameters:
 			# This is probably a mistake in the logic as $localEndpoint is always being overrided
 			message: '#Parameter \#1 \$localEndpoint of class Zipkin\\DefaultTracing constructor expects Zipkin\\Endpoint, Zipkin\\Endpoint\|null given#'
 			path: src/Zipkin/TracingBuilder.php
+		-
+			# This avoids false positive in quirky HTTP reporter constructor
+			message: '#Zipkin\\Reporters\\Http\:\:\_\_construct\(\)#'
+			path: src/Zipkin/Reporters/Http.php
+		-
+			# This avoids false positive in quirky HTTP reporter constructor
+			message: '#Strict comparison using \=\=\=#'
+			path: src/Zipkin/Reporters/Http.php

--- a/src/Zipkin/Reporters/Http.php
+++ b/src/Zipkin/Reporters/Http.php
@@ -69,19 +69,19 @@ final class Http implements Reporter
         if ($options === self::EMPTY_ARG) {
             // means no arguments because first argument wasn't nullable in v1
             $parsedOptions = [];
-        } elseif (is_array($options) && (($requesterFactory instanceof ClientFactory) || $requesterFactory == null)) {
+        } elseif (\is_array($options) && (($requesterFactory instanceof ClientFactory) || $requesterFactory == null)) {
             // means the intention of the first argument is the `options`
             $parsedOptions = $options;
-        } elseif ($options instanceof ClientFactory && (is_array($requesterFactory) || $requesterFactory === null)) {
+        } elseif ($options instanceof ClientFactory && (\is_array($requesterFactory) || $requesterFactory === null)) {
             // means the intention of the first argument is the `ClientFactory`
             $parsedOptions = $requesterFactory ?? [];
             $requesterFactory = $options;
         } else {
             throw new TypeError(
-                sprintf(
+                \sprintf(
                     'Argument 1 passed to %s::__construct must be of type array, %s given',
                     self::class,
-                    $options === null ? 'null' : gettype($options)
+                    $options === null ? 'null' : \gettype($options)
                 )
             );
         }

--- a/tests/Unit/Reporters/HttpTest.php
+++ b/tests/Unit/Reporters/HttpTest.php
@@ -2,6 +2,7 @@
 
 namespace ZipkinTests\Unit\Reporters;
 
+use TypeError;
 use Zipkin\Endpoint;
 use Prophecy\Argument;
 use Zipkin\Recording\Span;
@@ -9,16 +10,42 @@ use Zipkin\Reporters\Http;
 use Psr\Log\LoggerInterface;
 use PHPUnit\Framework\TestCase;
 use Zipkin\Propagation\TraceContext;
+use Zipkin\Reporters\Http\CurlFactory;
 
 final class HttpTest extends TestCase
 {
     const PAYLOAD = '[{"id":"%s","name":null,"traceId":"%s","parentId":null,'
         . '"timestamp":null,"duration":null,"debug":false,"localEndpoint":{"serviceName":""}}]';
 
-    public function testCreateHttpReporterWithDefaultDependencies()
+    public function testConstructorIsRetrocompatible()
     {
-        $httpReporter = new Http();
-        $this->assertInstanceOf(Http::class, $httpReporter);
+        $this->assertInstanceOf(Http::class, new Http());
+
+        // old constructor
+        $this->assertInstanceOf(Http::class, new Http(CurlFactory::create()));
+        $this->assertInstanceOf(Http::class, new Http(
+            CurlFactory::create(),
+            ['endpoint_url' => 'http://myzipkin:9411/api/v2/spans',]
+        ));
+
+        // new constructor
+        $this->assertInstanceOf(Http::class, new Http(
+            ['endpoint_url' => 'http://localhost:9411/api/v2/spans']
+        ));
+        $this->assertInstanceOf(Http::class, new Http(
+            ['endpoint_url' => 'http://localhost:9411/api/v2/spans'],
+            CurlFactory::create()
+        ));
+
+        try {
+            new Http(null);
+            $this->fail('Expected the constructor to fail.');
+        } catch (TypeError $e) {
+            $this->assertEquals(
+                'Argument 1 passed to Zipkin\Reporters\Http::__construct must be of type array, null given',
+                $e->getMessage()
+            );
+        }
     }
 
     public function testHttpReporterSuccess()


### PR DESCRIPTION
https://github.com/openzipkin/zipkin-php/commit/c81026ae32ffd70771d3a5b994d2cec0feedba74#diff-542892a2dd974b841a279a65f6b8c93a introduced a breaking change in the constructor of the HTTP reporter, while the change makes sense we don't want apps to break apps. This PR fixes the retro compatibility issue so transition to v2 is smoother.

Ping @adriancole 