### PR TITLE
chore: accept null for the first parameter in the HTTP reporter.

### DIFF
--- a/src/Zipkin/Reporters/Http.php
+++ b/src/Zipkin/Reporters/Http.php
@@ -76,12 +76,15 @@ final class Http implements Reporter
             // means the intention of the first argument is the `ClientFactory`
             $parsedOptions = $requesterFactory ?? [];
             $requesterFactory = $options;
+        } elseif ($options === null) {
+            $parsedOptions = $requesterFactory ?? [];
+            $requesterFactory = null;
         } else {
             throw new TypeError(
                 \sprintf(
                     'Argument 1 passed to %s::__construct must be of type array, %s given',
                     self::class,
-                    $options === null ? 'null' : \gettype($options)
+                    \gettype($options)
                 )
             );
         }

--- a/tests/Unit/Reporters/HttpTest.php
+++ b/tests/Unit/Reporters/HttpTest.php
@@ -22,10 +22,14 @@ final class HttpTest extends TestCase
         $this->assertInstanceOf(Http::class, new Http());
 
         // old constructor
+        $this->assertInstanceOf(Http::class, new Http(
+            null,
+            ['endpoint_url' => 'http://myzipkin:9411/api/v2/spans']
+        ));
         $this->assertInstanceOf(Http::class, new Http(CurlFactory::create()));
         $this->assertInstanceOf(Http::class, new Http(
             CurlFactory::create(),
-            ['endpoint_url' => 'http://myzipkin:9411/api/v2/spans',]
+            ['endpoint_url' => 'http://myzipkin:9411/api/v2/spans']
         ));
 
         // new constructor
@@ -38,11 +42,11 @@ final class HttpTest extends TestCase
         ));
 
         try {
-            new Http(null);
+            new Http(1);
             $this->fail('Expected the constructor to fail.');
         } catch (TypeError $e) {
             $this->assertEquals(
-                'Argument 1 passed to Zipkin\Reporters\Http::__construct must be of type array, null given',
+                'Argument 1 passed to Zipkin\Reporters\Http::__construct must be of type array, integer given',
                 $e->getMessage()
             );
         }


### PR DESCRIPTION
Because https://github.com/jcchavezs/zipkin-instrumentation-symfony/blob/3771647/src/ZipkinBundle/TracingFactory.php#L65 which we will fix in origin but this means people could have done the same.