### PR TITLE
fix: RequestHeaders setter puts the value, overriding it if already exists.

### DIFF
--- a/src/Zipkin/Propagation/RequestHeaders.php
+++ b/src/Zipkin/Propagation/RequestHeaders.php
@@ -26,6 +26,6 @@ final class RequestHeaders implements Getter, Setter
     public function put(&$carrier, $key, $value)
     {
         $lKey = strtolower($key);
-        $carrier = $carrier->withAddedHeader($lKey, $value);
+        $carrier = $carrier->withHeader($lKey, $value);
     }
 }

--- a/tests/Unit/Propagation/RequestHeadersTest.php
+++ b/tests/Unit/Propagation/RequestHeadersTest.php
@@ -35,4 +35,13 @@ final class RequestHeadersTest extends PHPUnit_Framework_TestCase
         $value = $requestHeaders->get($request, self::TEST_KEY);
         $this->assertEquals(self::TEST_VALUE, $value);
     }
+
+    public function testPutOverridesWithTheExpectedValue()
+    {
+        $request = new Request('GET', '/');
+        $requestHeaders = new RequestHeaders([self::TEST_KEY => 'foobar']);
+        $requestHeaders->put($request, self::TEST_KEY, self::TEST_VALUE);
+        $value = $requestHeaders->get($request, self::TEST_KEY);
+        $this->assertEquals(self::TEST_VALUE, $value);
+    }
 }


### PR DESCRIPTION
This PR fixes a misleading behaviour of the method `RequestHeaders::put` as we were actually appending instead of overriding.