### PR TITLE
fix: RequestHeaders setter puts the value, overriding it if already exists.

### DIFF
--- a/src/Zipkin/Propagation/RequestHeaders.php
+++ b/src/Zipkin/Propagation/RequestHeaders.php
@@ -16,6 +16,9 @@ final class RequestHeaders implements Getter, Setter
     public function get($carrier, string $key): ?string
     {
         $lKey = \strtolower($key);
+
+        // We return the first value becase we relay on the fact that we
+        // always override the header value when put method is called.
         return $carrier->hasHeader($lKey) ? $carrier->getHeader($lKey)[0] : null;
     }
 
@@ -28,6 +31,6 @@ final class RequestHeaders implements Getter, Setter
     public function put(&$carrier, string $key, string $value): void
     {
         $lKey = \strtolower($key);
-        $carrier = $carrier->withAddedHeader($lKey, $value);
+        $carrier = $carrier->withHeader($lKey, $value);
     }
 }

--- a/tests/Unit/Propagation/RequestHeadersTest.php
+++ b/tests/Unit/Propagation/RequestHeadersTest.php
@@ -35,4 +35,13 @@ final class RequestHeadersTest extends TestCase
         $value = $requestHeaders->get($request, self::TEST_KEY);
         $this->assertEquals(self::TEST_VALUE, $value);
     }
+
+    public function testPutOverridesWithTheExpectedValue()
+    {
+        $request = new Request('GET', '/', [self::TEST_KEY => 'foobar']);
+        $requestHeaders = new RequestHeaders();
+        $requestHeaders->put($request, self::TEST_KEY, self::TEST_VALUE);
+        $value = $requestHeaders->get($request, self::TEST_KEY);
+        $this->assertEquals(self::TEST_VALUE, $value);
+    }
 }


### PR DESCRIPTION
Currently the put behaviour was misleading as it was **appending** values if the header already existed. With this change it will honor the name `put` as it will override whatever is in there.