### PR TITLE
fix: removes usesTraceId128bits from signature an infer from the traceId length.

### DIFF
--- a/src/Zipkin/Propagation/TraceContext.php
+++ b/src/Zipkin/Propagation/TraceContext.php
@@ -63,7 +63,6 @@ final class TraceContext implements SamplingFlags
      * @param string|null $parentId
      * @param bool|null $isSampled
      * @param bool $isDebug
-     * @param bool $usesTraceId128bits
      * @return TraceContext
      * @throws InvalidTraceContextArgument
      */
@@ -72,8 +71,7 @@ final class TraceContext implements SamplingFlags
         string $spanId,
         ?string $parentId = null,
         ?bool $isSampled = SamplingFlags::EMPTY_SAMPLED,
-        bool $isDebug = SamplingFlags::EMPTY_DEBUG,
-        bool $usesTraceId128bits = false
+        bool $isDebug = SamplingFlags::EMPTY_DEBUG
     ): TraceContext {
         if (!Id\isValidTraceId($traceId)) {
             throw InvalidTraceContextArgument::forTraceId($traceId);
@@ -87,7 +85,7 @@ final class TraceContext implements SamplingFlags
             throw InvalidTraceContextArgument::forParentSpanId($parentId);
         }
 
-        return new self($traceId, $spanId, $parentId, $isSampled, $isDebug, $usesTraceId128bits);
+        return new self($traceId, $spanId, $parentId, $isSampled, $isDebug, strlen($traceId) === 32);
     }
 
     /**

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -51,9 +51,9 @@ final class TracerTest extends TestCase
             Endpoint::createAsEmpty(),
             $this->reporter->reveal(),
             $this->sampler->reveal(),
-            false,
+            false, // usesTraceId128bits
             $this->currentTracerContext,
-            false
+            false // isNoop
         );
 
         $samplingFlags = DefaultSamplingFlags::create(true, false);
@@ -73,9 +73,9 @@ final class TracerTest extends TestCase
             Endpoint::createAsEmpty(),
             $this->reporter->reveal(),
             $this->sampler->reveal(),
-            true,
+            true, // usesTraceId128bits
             new CurrentTraceContext,
-            false
+            false // isNoop
         );
 
         $samplingFlags = DefaultSamplingFlags::create(true, false);


### PR DESCRIPTION
Currently we mistakenly allowed users to pass the `usesTraceId128bits` value which was misleading because it could happen the traceId was 64bit but we passed usesTraceId128bits = true. This was a bug and it is safe to remove as a) in case someone actually cares about the value of TraceContext::usesTraceId128bits, the value was misleading and b) even if someone was passing the value on the `TraceContext::create` method, PHP does not fail if you pass an additional argument.