### PR TITLE
fix(propagation): fixes map lookup for case insensitiviness.

### DIFF
--- a/src/Zipkin/Propagation/Map.php
+++ b/src/Zipkin/Propagation/Map.php
@@ -34,8 +34,16 @@ final class Map implements Getter, Setter
                 return null;
             }
 
-            $lcCarrier = \array_change_key_case($carrier, \CASE_LOWER);
-            return \array_key_exists($lKey, $lcCarrier) ? $lcCarrier[$lKey] : null;
+            /**
+             * @var string $k
+             */
+            foreach ($carrier as $k => $value) {
+                if (strtolower($k) === $lKey) {
+                    return $value;
+                }
+            }
+
+            return null;
         }
 
         throw InvalidPropagationCarrier::forCarrier($carrier);


### PR DESCRIPTION
Although not ideal, this implementation is more efficient as it only iterates the array until it is needed instead of changing the case for the full array every time.