### PR TITLE
Support extracting incoming headers from the $_SERVER variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,11 +213,19 @@ Here's what server-side propagation might look like
 
 ```php
 // configure a function that extracts the trace context from a request
-$extractor = $tracing->getPropagation()->extractor(new RequestHeaders);
+$extractor = $tracing->getPropagation()->getExtractor(new RequestHeaders);
 $extracted = $extractor($request)
 
 $span = $tracer->newChild($extracted)
 $span->setKind(Kind\SERVER);
+```
+
+If you aren't using a framework or don't have access to the Request object, you
+can extract the context from the $_SERVER variable
+
+```php
+$extractor = $tracing->getPropagation()->getExtractor(new ServerHeaders);
+$extracted = $extractor($_SERVER)
 ```
 
 ### Extracting a propagated context
@@ -289,6 +297,7 @@ request. To do this, simply pass null to `openScope`.
 Tests can be run by
 
 ```bash
+composer update
 composer test
 ```
 

--- a/README.md
+++ b/README.md
@@ -297,7 +297,6 @@ request. To do this, simply pass null to `openScope`.
 Tests can be run by
 
 ```bash
-composer update
 composer test
 ```
 

--- a/src/Zipkin/Propagation/ServerHeaders.php
+++ b/src/Zipkin/Propagation/ServerHeaders.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zipkin\Propagation;
+
+// This class implements the Zipkin getter interface to extract the zipkin
+// headers out of the $_SERVER variable.
+// Due to how the api is written, $_SERVER gets passed in as $carrier rather
+// than get accessed here directly.
+//
+// Example:
+//   $extractor = $this->tracing->getPropagation()->getExtractor(new ServerHeaders);
+//   $extractedContext = $extractor($_SERVER);
+final class ServerHeaders implements Getter
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @param mixed $carrier
+     * @param string $key
+     * @return string|null
+     */
+    public function get($carrier, string $key): ?string
+    {
+        // Headers in $_SERVER are always uppercased, with any - replaced with an _
+        $key = strtoupper($key);
+        $key = str_replace('-', '_', $key);
+
+        return $carrier['HTTP_' . $key] ?? null;
+    }
+}

--- a/src/Zipkin/Propagation/ServerHeaders.php
+++ b/src/Zipkin/Propagation/ServerHeaders.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace Zipkin\Propagation;
 
-// This class implements the Zipkin getter interface to extract the zipkin
-// headers out of the $_SERVER variable.
-// Due to how the api is written, $_SERVER gets passed in as $carrier rather
-// than get accessed here directly.
-//
-// Example:
-//   $extractor = $this->tracing->getPropagation()->getExtractor(new ServerHeaders);
-//   $extractedContext = $extractor($_SERVER);
+/**
+ *
+ * This class implements the Zipkin\Propagation\Getter interface to extract the zipkin
+ * headers out of the $_SERVER variable.
+ * Due to the Getter::get signature, $_SERVER gets passed in as $carrier rather
+ * than get accessed here directly.
+ *
+ * Example:
+ *   $extractor = $this->tracing->getPropagation()->getExtractor(new ServerHeaders);
+ *   $extractedContext = $extractor($_SERVER);
+*/
 final class ServerHeaders implements Getter
 {
     /**

--- a/tests/Unit/Propagation/ServerHeadersTest.php
+++ b/tests/Unit/Propagation/ServerHeadersTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace ZipkinTests\Unit\Propagation;
+
+use PHPUnit\Framework\TestCase;
+use Zipkin\Propagation\B3;
+use Zipkin\Propagation\DefaultSamplingFlags;
+use Zipkin\Propagation\ServerHeaders;
+use Zipkin\Propagation\TraceContext;
+use function Zipkin\Propagation\Id\generateNextId;
+
+final class ServerHeadersTest extends TestCase
+{
+    public function testDoesntCrashIfNoHeaders()
+    {
+        $server = [];
+
+        $propagation = new B3();
+        $extractor = $propagation->getExtractor(new ServerHeaders);
+        $extracted = $extractor($server);
+
+        $this->assertTrue($extracted instanceof DefaultSamplingFlags);
+    }
+
+    public function testCorrectlyParsesHeaders()
+    {
+        $traceId = generateNextId();
+        $spanId = generateNextId();
+        $parentSpanId = generateNextId();
+        $server = [
+            'HTTP_X_B3_TRACEID' => $traceId,
+            'HTTP_X_B3_SPANID' => $spanId,
+            'HTTP_X_B3_PARENTSPANID' => $parentSpanId,
+            'HTTP_X_B3_SAMPLED' => '1',
+        ];
+
+        $propagation = new B3();
+        $extractor = $propagation->getExtractor(new ServerHeaders);
+        $extracted = $extractor($server);
+
+        $this->assertTrue($extracted instanceof TraceContext);
+        $this->assertEquals($traceId, $extracted->getTraceId());
+        $this->assertEquals($spanId, $extracted->getSpanId());
+        $this->assertEquals($parentSpanId, $extracted->getParentId());
+    }
+}


### PR DESCRIPTION
If you don't have access to a Request object, it's convenient to extract the headers from the global $_SERVER variable.