### PR TITLE
Allow using custom Recorder and add option to always record spans

### DIFF
--- a/src/Zipkin/DefaultTracing.php
+++ b/src/Zipkin/DefaultTracing.php
@@ -42,7 +42,8 @@ final class DefaultTracing implements Tracing
         CurrentTraceContext $currentTraceContext,
         bool $isNoop,
         Propagation $propagation,
-        bool $supportsJoin
+        bool $supportsJoin,
+        bool $alwaysEmitSpans = false
     ) {
         $this->tracer = new Tracer(
             $localEndpoint,
@@ -51,7 +52,8 @@ final class DefaultTracing implements Tracing
             $usesTraceId128bits,
             $currentTraceContext,
             $isNoop,
-            $supportsJoin
+            $supportsJoin,
+            $alwaysEmitSpans
         );
 
         $this->propagation = $propagation;

--- a/src/Zipkin/DefaultTracing.php
+++ b/src/Zipkin/DefaultTracing.php
@@ -43,7 +43,7 @@ final class DefaultTracing implements Tracing
         bool $isNoop,
         Propagation $propagation,
         bool $supportsJoin,
-        bool $alwaysEmitSpans = false
+        bool $alwaysReportSpans = false
     ) {
         $this->tracer = new Tracer(
             $localEndpoint,
@@ -53,7 +53,7 @@ final class DefaultTracing implements Tracing
             $currentTraceContext,
             $isNoop,
             $supportsJoin,
-            $alwaysEmitSpans
+            $alwaysReportSpans
         );
 
         $this->propagation = $propagation;

--- a/src/Zipkin/Recording/Span.php
+++ b/src/Zipkin/Recording/Span.php
@@ -128,7 +128,7 @@ final class Span
     private $localEndpoint;
 
     /**
-     * @var bool
+     * @var bool|null
      */
     private $isSampled;
 
@@ -139,7 +139,7 @@ final class Span
         bool $debug,
         bool $shared,
         Endpoint $localEndpoint,
-        bool $isSampled = false
+        ?bool $isSampled = false
     ) {
         $this->traceId = $traceId;
         $this->parentId = $parentId;
@@ -238,7 +238,7 @@ final class Span
      */
     public function isSampled(): bool
     {
-        return $this->isSampled;
+        return $this->isSampled === true;
     }
 
     /**

--- a/src/Zipkin/Recording/Span.php
+++ b/src/Zipkin/Recording/Span.php
@@ -127,13 +127,19 @@ final class Span
      */
     private $localEndpoint;
 
+    /**
+     * @var bool|null
+     */
+    private $isSampled;
+
     private function __construct(
         string $traceId,
         ?string $parentId,
         string $spanId,
         bool $debug,
         bool $shared,
-        Endpoint $localEndpoint
+        Endpoint $localEndpoint,
+        ?bool $isSampled = false
     ) {
         $this->traceId = $traceId;
         $this->parentId = $parentId;
@@ -141,6 +147,7 @@ final class Span
         $this->debug = $debug;
         $this->shared = $shared;
         $this->localEndpoint = $localEndpoint;
+        $this->isSampled = $isSampled;
     }
 
     /**
@@ -156,7 +163,8 @@ final class Span
             $context->getSpanId(),
             $context->isDebug(),
             $context->isShared(),
-            $localEndpoint
+            $localEndpoint,
+            $context->isSampled()
         );
     }
 
@@ -223,6 +231,14 @@ final class Span
     public function setRemoteEndpoint(Endpoint $remoteEndpoint): void
     {
         $this->remoteEndpoint = $remoteEndpoint;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isSampled(): bool
+    {
+        return $this->isSampled === true;
     }
 
     /**

--- a/src/Zipkin/Recording/Span.php
+++ b/src/Zipkin/Recording/Span.php
@@ -128,7 +128,7 @@ final class Span
     private $localEndpoint;
 
     /**
-     * @var bool|null
+     * @var bool
      */
     private $isSampled;
 
@@ -139,7 +139,7 @@ final class Span
         bool $debug,
         bool $shared,
         Endpoint $localEndpoint,
-        ?bool $isSampled = false
+        bool $isSampled = false
     ) {
         $this->traceId = $traceId;
         $this->parentId = $parentId;
@@ -238,7 +238,7 @@ final class Span
      */
     public function isSampled(): bool
     {
-        return $this->isSampled === true;
+        return $this->isSampled;
     }
 
     /**

--- a/src/Zipkin/Tracer.php
+++ b/src/Zipkin/Tracer.php
@@ -49,12 +49,18 @@ final class Tracer
     private $supportsJoin;
 
     /**
+     * @var bool
+     */
+    private $alwaysEmitSpans;
+
+    /**
      * @param Endpoint $localEndpoint
      * @param Reporter $reporter
      * @param Sampler $sampler
      * @param bool $usesTraceId128bits
      * @param CurrentTraceContext $currentTraceContext
      * @param bool $isNoop
+     * @param bool $alwaysEmitSpans
      */
     public function __construct(
         Endpoint $localEndpoint,
@@ -63,7 +69,8 @@ final class Tracer
         bool $usesTraceId128bits,
         CurrentTraceContext $currentTraceContext,
         bool $isNoop,
-        bool $supportsJoin = true
+        bool $supportsJoin = true,
+        bool $alwaysEmitSpans = false
     ) {
         $this->recorder = new Recorder($localEndpoint, $reporter, $isNoop);
         $this->sampler = $sampler;
@@ -71,6 +78,7 @@ final class Tracer
         $this->currentTraceContext = $currentTraceContext;
         $this->isNoop = $isNoop;
         $this->supportsJoin = $supportsJoin;
+        $this->alwaysEmitSpans = $alwaysEmitSpans;
     }
 
     /**
@@ -393,7 +401,7 @@ final class Tracer
      */
     private function toSpan(TraceContext $context): Span
     {
-        if (!$this->isNoop && $context->isSampled()) {
+        if (!$this->isNoop && ($context->isSampled() || $this->alwaysEmitSpans)) {
             return new RealSpan($context, $this->recorder);
         }
 

--- a/src/Zipkin/Tracer.php
+++ b/src/Zipkin/Tracer.php
@@ -51,7 +51,7 @@ final class Tracer
     /**
      * @var bool
      */
-    private $alwaysEmitSpans;
+    private $alwaysReportSpans;
 
     /**
      * @param Endpoint $localEndpoint
@@ -60,7 +60,7 @@ final class Tracer
      * @param bool $usesTraceId128bits
      * @param CurrentTraceContext $currentTraceContext
      * @param bool $isNoop
-     * @param bool $alwaysEmitSpans
+     * @param bool $alwaysReportSpans
      */
     public function __construct(
         Endpoint $localEndpoint,
@@ -70,7 +70,7 @@ final class Tracer
         CurrentTraceContext $currentTraceContext,
         bool $isNoop,
         bool $supportsJoin = true,
-        bool $alwaysEmitSpans = false
+        bool $alwaysReportSpans = false
     ) {
         $this->recorder = new Recorder($localEndpoint, $reporter, $isNoop);
         $this->sampler = $sampler;
@@ -78,7 +78,7 @@ final class Tracer
         $this->currentTraceContext = $currentTraceContext;
         $this->isNoop = $isNoop;
         $this->supportsJoin = $supportsJoin;
-        $this->alwaysEmitSpans = $alwaysEmitSpans;
+        $this->alwaysReportSpans = $alwaysReportSpans;
     }
 
     /**
@@ -401,7 +401,7 @@ final class Tracer
      */
     private function toSpan(TraceContext $context): Span
     {
-        if (!$this->isNoop && ($context->isSampled() || $this->alwaysEmitSpans)) {
+        if (!$this->isNoop && ($context->isSampled() || $this->alwaysReportSpans)) {
             return new RealSpan($context, $this->recorder);
         }
 

--- a/src/Zipkin/TracingBuilder.php
+++ b/src/Zipkin/TracingBuilder.php
@@ -189,6 +189,13 @@ class TracingBuilder
     }
 
     /**
+     * True means that spans will always be recorded, even if the current trace is not sampled.
+     * Defaults to False.
+     *
+     * This has the side effect that your reporter will receive all spans, irrespective of the
+     * sampling decision. Use this if you want to have some custom smart logic in the reporter
+     * that needs to have access to both sampled and unsampled traces.
+     *
      * @param bool $alwaysReportSpans
      * @return $this
      */

--- a/src/Zipkin/TracingBuilder.php
+++ b/src/Zipkin/TracingBuilder.php
@@ -58,6 +58,11 @@ class TracingBuilder
      */
     private $propagation = null;
 
+    /**
+     * @var bool
+     */
+    private $alwaysEmitSpans = false;
+
     public static function create(): self
     {
         return new self();
@@ -184,6 +189,16 @@ class TracingBuilder
     }
 
     /**
+     * @param bool $alwaysEmitSpans
+     * @return $this
+     */
+    public function alwaysEmittingSpans(bool $alwaysEmitSpans): self
+    {
+        $this->alwaysEmitSpans = $alwaysEmitSpans;
+        return $this;
+    }
+
+    /**
      * @return DefaultTracing
      */
     public function build(): Tracing
@@ -209,7 +224,8 @@ class TracingBuilder
             $currentTraceContext,
             $this->isNoop,
             $propagation,
-            $this->supportsJoin && $propagation->supportsJoin()
+            $this->supportsJoin && $propagation->supportsJoin(),
+            $this->alwaysEmitSpans
         );
     }
 }

--- a/src/Zipkin/TracingBuilder.php
+++ b/src/Zipkin/TracingBuilder.php
@@ -61,7 +61,7 @@ class TracingBuilder
     /**
      * @var bool
      */
-    private $alwaysEmitSpans = false;
+    private $alwaysReportSpans = false;
 
     public static function create(): self
     {
@@ -189,12 +189,12 @@ class TracingBuilder
     }
 
     /**
-     * @param bool $alwaysEmitSpans
+     * @param bool $alwaysReportSpans
      * @return $this
      */
-    public function alwaysEmittingSpans(bool $alwaysEmitSpans): self
+    public function alwaysReportingSpans(bool $alwaysReportSpans): self
     {
-        $this->alwaysEmitSpans = $alwaysEmitSpans;
+        $this->alwaysReportSpans = $alwaysReportSpans;
         return $this;
     }
 
@@ -225,7 +225,7 @@ class TracingBuilder
             $this->isNoop,
             $propagation,
             $this->supportsJoin && $propagation->supportsJoin(),
-            $this->alwaysEmitSpans
+            $this->alwaysReportSpans
         );
     }
 }

--- a/tests/Unit/TracingBuilderTest.php
+++ b/tests/Unit/TracingBuilderTest.php
@@ -89,7 +89,7 @@ final class TracingBuilderTest extends TestCase
 
     public function testAlwaysEmitSpans()
     {
-        // If `alwaysEmittingSpans(true)` is called, we should be emitting the
+        // If `alwaysReportingSpans(true)` is called, we should be emitting the
         // spans even if the trace isn't sampled
         $endpoint = Endpoint::createAsEmpty();
         $reporter = new InMemory();
@@ -100,7 +100,7 @@ final class TracingBuilderTest extends TestCase
             ->havingLocalEndpoint($endpoint)
             ->havingReporter($reporter)
             ->havingSampler($sampler)
-            ->alwaysEmittingSpans(true)
+            ->alwaysReportingSpans(true)
             ->build();
         $tracer = $tracing->getTracer();
 


### PR DESCRIPTION
This will let me implement "firehose mode", similar to what we have in
py_zipkin.

Basically what I need is a way to call 2 different Reporters:
- one gets called only when sampled is True
- one gets called every time (this is the firehose recorder)
This cannot be accomplished with just one Reporter, because once we're
inside the reporter we've lost any info on whether the trace was sampled
or not.

I can almost do this in zipkin-php, there are only 2 things missing.
- if sampled is False, we create a NoopSpan. So I need an extra flag to
  inform the tracer that I always want to create a RealSpan
- the Recorder is hardcoded inside the Tracer class, so I cannot pass my
  own.

Once those 2 things are supported, I can write my own Recorder subclass
that calls the right Reporters as needed with minimal changes to the
core zipkin-php code.

cc @adriancole 