### PR TITLE
feat(sampling-flags): adds withSampled method for SamplingFlags.

### DIFF
--- a/src/Zipkin/Propagation/DefaultSamplingFlags.php
+++ b/src/Zipkin/Propagation/DefaultSamplingFlags.php
@@ -22,59 +22,36 @@ final class DefaultSamplingFlags implements SamplingFlags
         $this->isDebug = $isDebug;
     }
 
-    /**
-     * @param bool|null $isSampled
-     * @param bool $isDebug
-     * @return DefaultSamplingFlags
-     */
     public static function create(?bool $isSampled, bool $isDebug = false): self
     {
         return new self($isSampled, $isDebug);
     }
 
-    /**
-     * @return DefaultSamplingFlags
-     */
     public static function createAsEmpty(): self
     {
         return new self(SamplingFlags::EMPTY_SAMPLED, SamplingFlags::EMPTY_DEBUG);
     }
 
-    /**
-     * @return DefaultSamplingFlags
-     */
     public static function createAsSampled(): self
     {
         return new self(true, false);
     }
 
-    /**
-     * @return DefaultSamplingFlags
-     */
     public static function createAsNotSampled(): self
     {
         return new self(false, false);
     }
 
-    /**
-     * @return DefaultSamplingFlags
-     */
     public static function createAsDebug(): self
     {
         return new self(null, true);
     }
 
-    /**
-     * @return bool|null
-     */
     public function isSampled(): ?bool
     {
         return $this->isSampled;
     }
 
-    /**
-     * @return bool
-     */
     public function isDebug(): bool
     {
         return $this->isDebug;
@@ -86,13 +63,17 @@ final class DefaultSamplingFlags implements SamplingFlags
         $this->isDebug === self::EMPTY_DEBUG;
     }
 
-    /**
-     * @param SamplingFlags $samplingFlags
-     * @return bool
-     */
     public function isEqual(SamplingFlags $samplingFlags): bool
     {
-        return $this->isDebug() === $samplingFlags->isDebug()
-            && $this->isSampled() === $samplingFlags->isSampled();
+        return $this->isDebug === $samplingFlags->isDebug()
+            && $this->isSampled === $samplingFlags->isSampled();
+    }
+
+    /**
+     * @return DefaultSamplingFlags
+     */
+    public function withSampled(bool $isSampled): SamplingFlags
+    {
+        return new self($isSampled, $this->isDebug);
     }
 }

--- a/src/Zipkin/Propagation/SamplingFlags.php
+++ b/src/Zipkin/Propagation/SamplingFlags.php
@@ -9,21 +9,13 @@ interface SamplingFlags
     const EMPTY_SAMPLED = null;
     const EMPTY_DEBUG = false;
 
-    /**
-     * @return bool|null
-     */
     public function isSampled(): ?bool;
 
-    /**
-     * @return bool
-     */
     public function isDebug(): bool;
 
     public function isEmpty(): bool;
 
-    /**
-     * @param SamplingFlags $samplingFlags
-     * @return bool
-     */
     public function isEqual(SamplingFlags $samplingFlags): bool;
+
+    public function withSampled(bool $isSampled): SamplingFlags;
 }

--- a/src/Zipkin/Propagation/TraceContext.php
+++ b/src/Zipkin/Propagation/TraceContext.php
@@ -206,10 +206,9 @@ final class TraceContext implements SamplingFlags
     }
 
     /**
-     * @param bool $isSampled
      * @return TraceContext
      */
-    public function withSampled(bool $isSampled): TraceContext
+    public function withSampled(bool $isSampled): SamplingFlags
     {
         return new TraceContext(
             $this->traceId,
@@ -248,17 +247,11 @@ final class TraceContext implements SamplingFlags
         return false;
     }
 
-    /**
-     * @param SamplingFlags $samplingFlags
-     * @return bool
-     */
     public function isEqual(SamplingFlags $samplingFlags): bool
     {
         return ($samplingFlags instanceof TraceContext)
             && $this->traceId === $samplingFlags->traceId
             && $this->spanId === $samplingFlags->spanId
-            && $this->parentId === $samplingFlags->parentId
-            && $this->isSampled === $samplingFlags->isSampled
-            && $this->isDebug === $samplingFlags->isDebug;
+            && $this->parentId === $samplingFlags->parentId;
     }
 }


### PR DESCRIPTION
Currently there it is only possible to override the sampling decision for trace context but not for sampling flags. This formalizes the use case to override the sampling in the SamplingFlags interface.

The use case is the popular "requestSampler" which changes the sampler decision based on a request (both for client and server).

The use case is in the usage of `Tracer::nextSpanWithSampler` as used in https://github.com/jcchavezs/zipkin-instrumentation-symfony/pull/70/files#diff-46b82fded07ac22b103293cbc8c3ebbeR60-R63

Ping @adriancole 