### PR TITLE
fix(propagation): fixes logic around sampling and debug to improve the API usability.

### DIFF
--- a/src/Zipkin/Propagation/DefaultSamplingFlags.php
+++ b/src/Zipkin/Propagation/DefaultSamplingFlags.php
@@ -74,6 +74,6 @@ final class DefaultSamplingFlags implements SamplingFlags
      */
     public function withSampled(bool $isSampled): SamplingFlags
     {
-        return new self($isSampled, SamplingFlags::EMPTY_DEBUG);
+        return new self($isSampled, false);
     }
 }

--- a/src/Zipkin/Propagation/DefaultSamplingFlags.php
+++ b/src/Zipkin/Propagation/DefaultSamplingFlags.php
@@ -24,7 +24,7 @@ final class DefaultSamplingFlags implements SamplingFlags
 
     public static function create(?bool $isSampled, bool $isDebug = false): self
     {
-        return new self($isSampled, $isDebug);
+        return new self($isDebug ?: $isSampled, $isDebug);
     }
 
     public static function createAsEmpty(): self
@@ -44,7 +44,7 @@ final class DefaultSamplingFlags implements SamplingFlags
 
     public static function createAsDebug(): self
     {
-        return new self(null, true);
+        return new self(true, true);
     }
 
     public function isSampled(): ?bool
@@ -74,6 +74,6 @@ final class DefaultSamplingFlags implements SamplingFlags
      */
     public function withSampled(bool $isSampled): SamplingFlags
     {
-        return new self($isSampled, $this->isDebug);
+        return new self($isSampled, SamplingFlags::EMPTY_DEBUG);
     }
 }

--- a/src/Zipkin/Propagation/DefaultSamplingFlags.php
+++ b/src/Zipkin/Propagation/DefaultSamplingFlags.php
@@ -18,13 +18,13 @@ final class DefaultSamplingFlags implements SamplingFlags
 
     private function __construct(?bool $isSampled, bool $isDebug)
     {
-        $this->isSampled = $isSampled;
+        $this->isSampled = $isDebug ?: $isSampled;
         $this->isDebug = $isDebug;
     }
 
     public static function create(?bool $isSampled, bool $isDebug = false): self
     {
-        return new self($isDebug ?: $isSampled, $isDebug);
+        return new self($isSampled, $isDebug);
     }
 
     public static function createAsEmpty(): self

--- a/src/Zipkin/Propagation/TraceContext.php
+++ b/src/Zipkin/Propagation/TraceContext.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Zipkin\Propagation;
 
-use Zipkin\Propagation\DefaultSamplingFlags;
+use function Zipkin\Propagation\Id\generateTraceIdWith128bits;
 use Zipkin\Propagation\SamplingFlags;
 use Zipkin\Propagation\Exceptions\InvalidTraceContextArgument;
-use function Zipkin\Propagation\Id\generateTraceIdWith128bits;
+use Zipkin\Propagation\DefaultSamplingFlags;
 
 final class TraceContext implements SamplingFlags
 {
@@ -58,7 +58,7 @@ final class TraceContext implements SamplingFlags
         $this->traceId = $traceId;
         $this->spanId = $spanId;
         $this->parentId = $parentId;
-        $this->isSampled = $isSampled;
+        $this->isSampled = $isDebug ?: $isSampled;
         $this->isDebug = $isDebug;
         $this->isShared = $isShared;
         $this->usesTraceId128bits = $usesTraceId128bits;
@@ -215,7 +215,7 @@ final class TraceContext implements SamplingFlags
             $this->spanId,
             $this->parentId,
             $isSampled,
-            $this->isDebug,
+            false,
             $this->usesTraceId128bits,
             $this->isShared
         );

--- a/src/Zipkin/Tracer.php
+++ b/src/Zipkin/Tracer.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace Zipkin;
 
-use Throwable;
-use Zipkin\Sampler;
-use RuntimeException;
-use Zipkin\SpanCustomizer;
-use BadMethodCallException;
+use function Zipkin\SpanName\generateSpanName;
 use Zipkin\SpanCustomizerShield;
+use Zipkin\SpanCustomizer;
+use Zipkin\Sampler;
 use Zipkin\Propagation\TraceContext;
 use Zipkin\Propagation\SamplingFlags;
-use Zipkin\Propagation\CurrentTraceContext;
 use Zipkin\Propagation\DefaultSamplingFlags;
-use function Zipkin\SpanName\generateSpanName;
+use Zipkin\Propagation\CurrentTraceContext;
+use Throwable;
+use RuntimeException;
+use BadMethodCallException;
 
 final class Tracer
 {

--- a/tests/Unit/Propagation/DefaultSamplingFlagsTest.php
+++ b/tests/Unit/Propagation/DefaultSamplingFlagsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace ZipkinTests\Unit\Propagation;
+
+use Zipkin\Propagation\DefaultSamplingFlags;
+use PHPUnit\Framework\TestCase;
+
+final class DefaultSamplingFlagsTest extends TestCase
+{
+    public function testSamplingFlagsAreCreatedSuccessfully()
+    {
+        $samplingFlags0 = DefaultSamplingFlags::create(null, false);
+        $this->assertNull($samplingFlags0->isSampled());
+        $this->assertFalse($samplingFlags0->isDebug());
+  
+        $samplingFlags1 = DefaultSamplingFlags::create(true, false);
+        $this->assertTrue($samplingFlags1->isSampled());
+        $this->assertFalse($samplingFlags1->isDebug());
+
+        $samplingFlags2 = DefaultSamplingFlags::create(false, false);
+        $this->assertFalse($samplingFlags2->isSampled());
+        $this->assertFalse($samplingFlags2->isDebug());
+    }
+
+    public function testDebugOverridesSamplingDecision()
+    {
+        $samplingFlags = DefaultSamplingFlags::create(false, true);
+        $this->assertTrue($samplingFlags->isSampled());
+    }
+}

--- a/tests/Unit/Propagation/TraceContextTest.php
+++ b/tests/Unit/Propagation/TraceContextTest.php
@@ -31,7 +31,7 @@ final class TraceContextTest extends TestCase
     }
 
     /**
-     * @dataProvider boolProvider
+     * @dataProvider sampledDebugProvider
      */
     public function testCreateAsRootSuccess($sampled, $debug)
     {
@@ -46,7 +46,7 @@ final class TraceContextTest extends TestCase
     }
 
     /**
-     * @dataProvider boolProvider
+     * @dataProvider sampledDebugProvider
      */
     public function testCreateAsRootSuccessWithTraceId128bits($sampled, $debug)
     {
@@ -63,7 +63,7 @@ final class TraceContextTest extends TestCase
     }
 
     /**
-     * @dataProvider boolProvider
+     * @dataProvider sampledDebugProvider
      */
     public function testCreateFromParentSuccess($sampled, $debug)
     {
@@ -86,7 +86,7 @@ final class TraceContextTest extends TestCase
     }
 
     /**
-     * @dataProvider boolProvider
+     * @dataProvider sampledDebugProvider
      */
     public function testChangeSampledSuccess($sampled, $debug)
     {
@@ -107,11 +107,11 @@ final class TraceContextTest extends TestCase
         $this->assertEquals($traceContext->getTraceId(), $newTraceContext->getTraceId());
         $this->assertEquals($traceContext->getParentId(), $newTraceContext->getParentId());
         $this->assertEquals($newSampled, $newTraceContext->isSampled());
-        $this->assertEquals($traceContext->isDebug(), $newTraceContext->isDebug());
+        $this->assertFalse($newTraceContext->isDebug());
     }
 
     /**
-     * @dataProvider boolProvider
+     * @dataProvider sampledDebugProvider
      */
     public function testCreateFailsDueToInvalidId($sampled, $debug)
     {
@@ -128,7 +128,7 @@ final class TraceContextTest extends TestCase
     }
 
     /**
-     * @dataProvider boolProvider
+     * @dataProvider sampledDebugProvider
      */
     public function testCreateFailsDueToInvalidSpanId($sampled, $debug)
     {
@@ -145,7 +145,7 @@ final class TraceContextTest extends TestCase
     }
 
     /**
-     * @dataProvider boolProvider
+     * @dataProvider sampledDebugProvider
      */
     public function testCreateFailsDueToInvalidParentSpanId($sampled, $debug)
     {
@@ -162,7 +162,7 @@ final class TraceContextTest extends TestCase
     }
 
     /**
-     * @dataProvider boolProvider
+     * @dataProvider sampledDebugProvider
      */
     public function testIsEqualSuccessOnEqualContexts($sampled, $debug)
     {
@@ -186,7 +186,7 @@ final class TraceContextTest extends TestCase
     }
 
     /**
-     * @dataProvider boolProvider
+     * @dataProvider sampledDebugProvider
      */
     public function testIsEqualSuccessOnDifferentContexts($sampled, $debug)
     {
@@ -250,12 +250,12 @@ final class TraceContextTest extends TestCase
         $this->assertTrue($sharedTraceContext->isEqual($traceContext));
     }
 
-    public function boolProvider()
+    public function sampledDebugProvider()
     {
         return [
             [true, true],
             [true, false],
-            [false, true],
+            // [false, false] is a non sense combination, hence ignored.
             [false, false],
         ];
     }

--- a/tests/Unit/Propagation/TraceContextTest.php
+++ b/tests/Unit/Propagation/TraceContextTest.php
@@ -255,7 +255,7 @@ final class TraceContextTest extends TestCase
         return [
             [true, true],
             [true, false],
-            // [false, false] is a non sense combination, hence ignored.
+            // [false, true] is a non sense combination, hence ignored.
             [false, false],
         ];
     }


### PR DESCRIPTION
From now on, debug=true will force a sampled=true value in the TraceContext, making it easier for users to just check $context->isSampled() instead of also checking the $context->isDebug().

Ping @adriancole 