### PR TITLE
tests(http): covers http client/server request/response.

### DIFF
--- a/src/Zipkin/Instrumentation/Http/Client/Psr18/Request.php
+++ b/src/Zipkin/Instrumentation/Http/Client/Psr18/Request.php
@@ -32,7 +32,7 @@ final class Request extends ClientRequest
      */
     public function getPath(): ?string
     {
-        return $this->delegate->getUri()->getPath();
+        return $this->delegate->getUri()->getPath() ?: '/';
     }
 
     /**

--- a/src/Zipkin/Instrumentation/Http/Client/Psr18/Response.php
+++ b/src/Zipkin/Instrumentation/Http/Client/Psr18/Response.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Zipkin\Instrumentation\Http\Client\Psr18;
 
-use Zipkin\Instrumentation\Http\Request as HttpRequest;
 use Zipkin\Instrumentation\Http\Client\Response as ClientResponse;
+use Zipkin\Instrumentation\Http\Client\Request as ClientRequest;
 use Psr\Http\Message\ResponseInterface;
 
 final class Response extends ClientResponse
@@ -31,7 +31,7 @@ final class Response extends ClientResponse
     /**
      * {@inheritdoc}
      */
-    public function getRequest(): ?HttpRequest
+    public function getRequest(): ?ClientRequest
     {
         return $this->request;
     }

--- a/src/Zipkin/Instrumentation/Http/Client/Request.php
+++ b/src/Zipkin/Instrumentation/Http/Client/Request.php
@@ -6,6 +6,9 @@ namespace Zipkin\Instrumentation\Http\Client;
 
 use Zipkin\Instrumentation\Http\Request as HttpRequest;
 
+/**
+ * {@inheritdoc}
+ */
 abstract class Request extends HttpRequest
 {
 }

--- a/src/Zipkin/Instrumentation/Http/Client/Response.php
+++ b/src/Zipkin/Instrumentation/Http/Client/Response.php
@@ -6,6 +6,16 @@ namespace Zipkin\Instrumentation\Http\Client;
 
 use Zipkin\Instrumentation\Http\Response as HttpResponse;
 
+/**
+ * {@inheritdoc}
+ */
 abstract class Response extends HttpResponse
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function getRequest(): ?Request
+    {
+        return null;
+    }
 }

--- a/src/Zipkin/Instrumentation/Http/Request.php
+++ b/src/Zipkin/Instrumentation/Http/Request.php
@@ -6,6 +6,8 @@ namespace Zipkin\Instrumentation\Http;
 
 /**
  * Abstract request type used for parsing and sampling of http clients and servers.
+ *
+ * @internal
  */
 abstract class Request
 {

--- a/src/Zipkin/Instrumentation/Http/Response.php
+++ b/src/Zipkin/Instrumentation/Http/Response.php
@@ -4,15 +4,20 @@ declare(strict_types=1);
 
 namespace Zipkin\Instrumentation\Http;
 
+/**
+ * Abstract response type used for parsing and sampling of http clients and servers.
+ *
+ * @internal
+ */
 abstract class Response
 {
     /**
      * The request that initiated this response or {@code null} if unknown.
+     *
+     * @return Request|null not declared on purpose so client/server responses can
+     * declare its own type.
      */
-    public function getRequest(): ?Request
-    {
-        return null;
-    }
+    abstract public function getRequest();
 
     /**
      * The HTTP status code or zero if unreadable.

--- a/src/Zipkin/Instrumentation/Http/Server/Psr15/Request.php
+++ b/src/Zipkin/Instrumentation/Http/Server/Psr15/Request.php
@@ -7,6 +7,9 @@ namespace Zipkin\Instrumentation\Http\Server\Psr15;
 use Zipkin\Instrumentation\Http\Server\Request as ServerRequest;
 use Psr\Http\Message\RequestInterface;
 
+/**
+ * {@inheritdoc}
+ */
 final class Request extends ServerRequest
 {
     /**
@@ -32,7 +35,7 @@ final class Request extends ServerRequest
      */
     public function getPath(): ?string
     {
-        return $this->delegate->getUri()->getPath();
+        return $this->delegate->getUri()->getPath() ?: '/';
     }
 
     /**

--- a/src/Zipkin/Instrumentation/Http/Server/Psr15/Response.php
+++ b/src/Zipkin/Instrumentation/Http/Server/Psr15/Response.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Zipkin\Instrumentation\Http\Server\Psr15;
 
 use Zipkin\Instrumentation\Http\Server\Response as ServerResponse;
-use Zipkin\Instrumentation\Http\Request;
+use Zipkin\Instrumentation\Http\Server\Request as ServerRequest;
 use Psr\Http\Message\ResponseInterface;
 
+/**
+ * {@inheritdoc}
+ */
 final class Response extends ServerResponse
 {
     /**
@@ -31,7 +34,7 @@ final class Response extends ServerResponse
     /**
      * {@inheritdoc}
      */
-    public function getRequest(): ?Request
+    public function getRequest(): ?ServerRequest
     {
         return $this->request;
     }

--- a/src/Zipkin/Instrumentation/Http/Server/Request.php
+++ b/src/Zipkin/Instrumentation/Http/Server/Request.php
@@ -6,6 +6,9 @@ namespace Zipkin\Instrumentation\Http\Server;
 
 use Zipkin\Instrumentation\Http\Request as HttpRequest;
 
+/**
+ * {@inheritdoc}
+ */
 abstract class Request extends HttpRequest
 {
     /**

--- a/src/Zipkin/Instrumentation/Http/Server/Response.php
+++ b/src/Zipkin/Instrumentation/Http/Server/Response.php
@@ -6,6 +6,16 @@ namespace Zipkin\Instrumentation\Http\Server;
 
 use Zipkin\Instrumentation\Http\Response as HttpResponse;
 
+/**
+ * {@inheritdoc}
+ */
 abstract class Response extends HttpResponse
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function getRequest(): ?Request
+    {
+        return null;
+    }
 }

--- a/tests/Unit/Instrumentation/Http/Client/Psr18/RequestTest.php
+++ b/tests/Unit/Instrumentation/Http/Client/Psr18/RequestTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZipkinTests\Unit\Instrumentation\Http\Client\Psr18;
+
+use Zipkin\Instrumentation\Http\Client\Psr18\Request;
+use PHPUnit\Framework\TestCase;
+use GuzzleHttp\Psr7\Request as Psr7Request;
+
+final class RequestTest extends TestCase
+{
+    public function testRequestIsCreatedSuccessfully()
+    {
+        $delegateRequest = new Psr7Request('GET', 'http://test.com/path', ['test_key' => 'test_value']);
+        $request = new Request($delegateRequest);
+        $this->assertEquals('GET', $request->getMethod());
+        $this->assertEquals('/path', $request->getPath());
+        $this->assertNull($request->getHeader('test_missing_key'));
+        $this->assertEquals('test_value', $request->getHeader('test_key'));
+        $this->assertSame($delegateRequest, $request->unwrap());
+    }
+
+    /**
+     * @dataProvider emptyPaths
+     */
+    public function testRequestIsNormalizesEmptyPath(string $path)
+    {
+        $delegateRequest = new Psr7Request('GET', $path, ['test_key' => 'test_value']);
+        $request = new Request($delegateRequest);
+        $this->assertEquals('/', $request->getPath());
+    }
+
+    public function emptyPaths(): array
+    {
+        return [
+            ['http://test.com'],
+            ['http://test.com/'],
+        ];
+    }
+}

--- a/tests/Unit/Instrumentation/Http/Client/Psr18/ResponseTest.php
+++ b/tests/Unit/Instrumentation/Http/Client/Psr18/ResponseTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZipkinTests\Unit\Instrumentation\Http\Client\Psr18;
+
+use Zipkin\Instrumentation\Http\Client\Psr18\Response as Psr18Response;
+use Zipkin\Instrumentation\Http\Client\Psr18\Request;
+use PHPUnit\Framework\TestCase;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Request as Psr7Request;
+
+final class ResponseTest extends TestCase
+{
+    /**
+     * @dataProvider delegateRequests
+     */
+    public function testResponseIsCreatedSuccessfully($request)
+    {
+        $delegateResponse = new Response(202);
+        $response = new Psr18Response($delegateResponse, $request);
+        $this->assertEquals(202, $response->getStatusCode());
+        $this->assertSame($request, $response->getRequest());
+        $this->assertSame($delegateResponse, $response->unwrap());
+    }
+
+    public function delegateRequests(): array
+    {
+        return [
+            [null],
+            [new Request(new Psr7Request('GET', 'http://test.com/path'))],
+        ];
+    }
+}

--- a/tests/Unit/Instrumentation/Http/Server/Psr15/RequestTest.php
+++ b/tests/Unit/Instrumentation/Http/Server/Psr15/RequestTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZipkinTests\Unit\Instrumentation\Http\Server\Psr15;
+
+use Zipkin\Instrumentation\Http\Server\Psr15\Request;
+use PHPUnit\Framework\TestCase;
+use GuzzleHttp\Psr7\Request as Psr7Request;
+
+final class RequestTest extends TestCase
+{
+    public function testRequestIsCreatedSuccessfully()
+    {
+        $delegateRequest = new Psr7Request('GET', 'http://test.com/path', ['test_key' => 'test_value']);
+        $request = new Request($delegateRequest);
+        $this->assertEquals('GET', $request->getMethod());
+        $this->assertEquals('/path', $request->getPath());
+        $this->assertNull($request->getHeader('test_missing_key'));
+        $this->assertEquals('test_value', $request->getHeader('test_key'));
+        $this->assertSame($delegateRequest, $request->unwrap());
+    }
+
+    /**
+     * @dataProvider emptyPaths
+     */
+    public function testRequestIsNormalizesEmptyPath(string $path)
+    {
+        $delegateRequest = new Psr7Request('GET', 'http://test.com', ['test_key' => 'test_value']);
+        $request = new Request($delegateRequest);
+        $this->assertEquals('/', $request->getPath());
+    }
+
+    public function emptyPaths(): array
+    {
+        return [
+            ['http://test.com'],
+            ['http://test.com/'],
+        ];
+    }
+}

--- a/tests/Unit/Instrumentation/Http/Server/Psr15/ResponseTest.php
+++ b/tests/Unit/Instrumentation/Http/Server/Psr15/ResponseTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ZipkinTests\Unit\Instrumentation\Http\Server\Psr15;
+
+use Zipkin\Instrumentation\Http\Server\Psr15\Response as Psr15Response;
+use Zipkin\Instrumentation\Http\Server\Psr15\Request;
+use PHPUnit\Framework\TestCase;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Request as Psr7Request;
+
+final class ResponseTest extends TestCase
+{
+    /**
+     * @dataProvider delegateRequests
+     */
+    public function testResponseIsCreatedSuccessfully($request)
+    {
+        $delegateResponse = new Response(202);
+        $response = new Psr15Response($delegateResponse, $request);
+        $this->assertEquals(202, $response->getStatusCode());
+        $this->assertSame($request, $response->getRequest());
+        $this->assertSame($delegateResponse, $response->unwrap());
+    }
+
+    public function delegateRequests(): array
+    {
+        return [
+            [null],
+            [new Request(new Psr7Request('GET', 'http://test.com/path'))],
+        ];
+    }
+}


### PR DESCRIPTION
This PR covers the Request/Response value objects for client and server abstractions. It also makes it open the return type for `Response::getRequest` so the extending classes can decide.