### PR TITLE
chore(http): adds return type for PSR parsing request and response.

### DIFF
--- a/src/Zipkin/Instrumentation/Http/Client/Psr18/Request.php
+++ b/src/Zipkin/Instrumentation/Http/Client/Psr18/Request.php
@@ -53,10 +53,8 @@ final class Request extends ClientRequest
 
     /**
      * {@inheritdoc}
-     *
-     * @return RequestInterface
      */
-    public function unwrap()
+    public function unwrap(): RequestInterface
     {
         return $this->delegate;
     }

--- a/src/Zipkin/Instrumentation/Http/Client/Psr18/Response.php
+++ b/src/Zipkin/Instrumentation/Http/Client/Psr18/Response.php
@@ -46,10 +46,8 @@ final class Response extends ClientResponse
 
     /**
      * {@inheritdoc}
-     *
-     * @return ResponseInterface
      */
-    public function unwrap()
+    public function unwrap(): ResponseInterface
     {
         return $this->delegate;
     }

--- a/src/Zipkin/Instrumentation/Http/Server/Psr15/Request.php
+++ b/src/Zipkin/Instrumentation/Http/Server/Psr15/Request.php
@@ -56,10 +56,8 @@ final class Request extends ServerRequest
 
     /**
      * {@inheritdoc}
-     *
-     * @return RequestInterface
      */
-    public function unwrap()
+    public function unwrap(): RequestInterface
     {
         return $this->delegate;
     }

--- a/src/Zipkin/Instrumentation/Http/Server/Psr15/Response.php
+++ b/src/Zipkin/Instrumentation/Http/Server/Psr15/Response.php
@@ -49,10 +49,8 @@ final class Response extends ServerResponse
 
     /**
      * {@inheritdoc}
-     *
-     * @return ResponseInterface
      */
-    public function unwrap()
+    public function unwrap(): ResponseInterface
     {
         return $this->delegate;
     }


### PR DESCRIPTION
This adds type guards on the return type and it is convenient as these classes are final.