### PR TITLE
chore(http): renames http parser into a more specific name so it is e…

### DIFF
--- a/src/Zipkin/Instrumentation/Http/Client/DefaultHttpClientParser.php
+++ b/src/Zipkin/Instrumentation/Http/Client/DefaultHttpClientParser.php
@@ -9,17 +9,17 @@ use Zipkin\SpanCustomizer;
 use Zipkin\Propagation\TraceContext;
 use Zipkin\Instrumentation\Http\Response;
 use Zipkin\Instrumentation\Http\Request;
-use Zipkin\Instrumentation\Http\Client\Parser;
+use Zipkin\Instrumentation\Http\Client\HttpClientParser;
 
 /**
  * DefaultParser contains the basic logic for turning request/response information
  * into span name and tags. Implementors can use this as a base parser to reduce
  * boilerplate.
  */
-class DefaultParser implements Parser
+class DefaultHttpClientParser implements HttpClientParser
 {
     /**
-     * spanName returns an appropiate span name based on the request,
+     * spanName returns an appropriate span name based on the request,
      * usually the HTTP method is enough (e.g GET or POST).
      */
     protected function spanName(Request $request): string

--- a/src/Zipkin/Instrumentation/Http/Client/HttpClientParser.php
+++ b/src/Zipkin/Instrumentation/Http/Client/HttpClientParser.php
@@ -13,7 +13,7 @@ use Zipkin\Instrumentation\Http\Request;
  * Parser includes the methods to obtain meaningful span information
  * out of HTTP request/response elements.
  */
-interface Parser
+interface HttpClientParser
 {
     /**
      * request parses the incoming data related to a request in order to add

--- a/src/Zipkin/Instrumentation/Http/Client/HttpClientTracing.php
+++ b/src/Zipkin/Instrumentation/Http/Client/HttpClientTracing.php
@@ -19,7 +19,7 @@ class HttpClientTracing
     private $tracing;
 
     /**
-     * @var Parser
+     * @var HttpClientParser
      */
     private $parser;
 
@@ -33,11 +33,11 @@ class HttpClientTracing
 
     public function __construct(
         Tracing $tracing,
-        Parser $parser = null,
+        HttpClientParser $parser = null,
         callable $requestSampler = null
     ) {
         $this->tracing = $tracing;
-        $this->parser = $parser ?? new DefaultParser;
+        $this->parser = $parser ?? new DefaultHttpClientParser;
         $this->requestSampler = $requestSampler;
     }
 
@@ -54,7 +54,7 @@ class HttpClientTracing
         return $this->requestSampler;
     }
 
-    public function getParser(): Parser
+    public function getParser(): HttpClientParser
     {
         return $this->parser;
     }

--- a/src/Zipkin/Instrumentation/Http/Client/Psr18/Client.php
+++ b/src/Zipkin/Instrumentation/Http/Client/Psr18/Client.php
@@ -9,7 +9,7 @@ use Zipkin\SpanCustomizerShield;
 use Zipkin\Propagation\TraceContext;
 use Zipkin\Kind;
 use Zipkin\Instrumentation\Http\Client\Psr18\Propagation\RequestHeaders;
-use Zipkin\Instrumentation\Http\Client\Parser;
+use Zipkin\Instrumentation\Http\Client\HttpClientParser;
 use Zipkin\Instrumentation\Http\Client\HttpClientTracing;
 use Throwable;
 use Psr\Http\Message\ResponseInterface;
@@ -34,7 +34,7 @@ final class Client implements ClientInterface
     private $tracer;
 
     /**
-     * @var Parser
+     * @var HttpClientParser
      */
     private $parser;
 

--- a/src/Zipkin/Instrumentation/Http/Client/Request.php
+++ b/src/Zipkin/Instrumentation/Http/Client/Request.php
@@ -6,9 +6,6 @@ namespace Zipkin\Instrumentation\Http\Client;
 
 use Zipkin\Instrumentation\Http\Request as HttpRequest;
 
-/**
- * {@inheritdoc}
- */
 abstract class Request extends HttpRequest
 {
 }

--- a/src/Zipkin/Instrumentation/Http/Client/Response.php
+++ b/src/Zipkin/Instrumentation/Http/Client/Response.php
@@ -6,9 +6,6 @@ namespace Zipkin\Instrumentation\Http\Client;
 
 use Zipkin\Instrumentation\Http\Response as HttpResponse;
 
-/**
- * {@inheritdoc}
- */
 abstract class Response extends HttpResponse
 {
     /**

--- a/src/Zipkin/Instrumentation/Http/Request.php
+++ b/src/Zipkin/Instrumentation/Http/Request.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Zipkin\Instrumentation\Http;
 
+use const Zipkin\Tags\HTTP_METHOD;
+use const Zipkin\Tags\HTTP_PATH;
+use const Zipkin\Tags\HTTP_URL;
+
 /**
  * Abstract request type used for parsing and sampling of http clients and servers.
  *
@@ -20,7 +24,7 @@ abstract class Request
      * <p>It is part of the <a href="https://tools.ietf.org/html/rfc7231#section-4.1">HTTP RFC</a>
      * that an HTTP method is case-sensitive. Do not downcase results.
      *
-     * @see Zipkin\Tags\HTTP_METHOD
+     * @see HTTP_METHOD
      */
     abstract public function getMethod(): string;
 
@@ -37,7 +41,7 @@ abstract class Request
      * normalize "" to "/". This ensures values are consistent with wire-level clients and behaviour
      * consistent with RFC 7230 Section 2.7.3.
      *
-     * @see Zipkin\Tags\HTTP_PATH
+     * @see HTTP_PATH
      */
     abstract public function getPath(): ?string;
 
@@ -46,7 +50,7 @@ abstract class Request
      *
      * <p>Conventionally associated with the key "http.url"
      *
-     * @see Zipkin\Tags\HTTP_URL
+     * @see HTTP_URL
      */
     abstract public function getUrl(): string;
 

--- a/src/Zipkin/Instrumentation/Http/Server/DefaultHttpServerParser.php
+++ b/src/Zipkin/Instrumentation/Http/Server/DefaultHttpServerParser.php
@@ -7,14 +7,14 @@ namespace Zipkin\Instrumentation\Http\Server;
 use Zipkin\Tags;
 use Zipkin\SpanCustomizer;
 use Zipkin\Propagation\TraceContext;
-use Zipkin\Instrumentation\Http\Server\Parser;
+use Zipkin\Instrumentation\Http\Server\HttpServerParser;
 
 /**
  * DefaultParser contains the basic logic for turning request/response information
  * into span name and tags. Implementors can use this as a base parser to reduce
  * boilerplate.
  */
-class DefaultParser implements Parser
+class DefaultHttpServerParser implements HttpServerParser
 {
     /**
      * spanName returns an appropiate span name based on the request,

--- a/src/Zipkin/Instrumentation/Http/Server/HttpServerParser.php
+++ b/src/Zipkin/Instrumentation/Http/Server/HttpServerParser.php
@@ -11,7 +11,7 @@ use Zipkin\Propagation\TraceContext;
  * Parser includes the methods to obtain meaningful span information
  * out of HTTP request/response elements.
  */
-interface Parser
+interface HttpServerParser
 {
     /**
      * request parses the incoming data related to a request in order to add

--- a/src/Zipkin/Instrumentation/Http/Server/HttpServerTracing.php
+++ b/src/Zipkin/Instrumentation/Http/Server/HttpServerTracing.php
@@ -18,7 +18,7 @@ class HttpServerTracing
     private $tracing;
 
     /**
-     * @var Parser
+     * @var HttpServerParser
      */
     private $parser;
 
@@ -32,11 +32,11 @@ class HttpServerTracing
 
     public function __construct(
         Tracing $tracing,
-        Parser $parser = null,
+        HttpServerParser $parser = null,
         callable $requestSampler = null
     ) {
         $this->tracing = $tracing;
-        $this->parser = $parser ?? new DefaultParser;
+        $this->parser = $parser ?? new DefaultHttpServerParser;
         $this->requestSampler = $requestSampler;
     }
 
@@ -53,7 +53,7 @@ class HttpServerTracing
         return $this->requestSampler;
     }
 
-    public function getParser(): Parser
+    public function getParser(): HttpServerParser
     {
         return $this->parser;
     }

--- a/src/Zipkin/Instrumentation/Http/Server/Psr15/Middleware.php
+++ b/src/Zipkin/Instrumentation/Http/Server/Psr15/Middleware.php
@@ -13,7 +13,7 @@ use Zipkin\Propagation\DefaultSamplingFlags;
 use Zipkin\Kind;
 use Zipkin\Instrumentation\Http\Server\Request as ServerRequest;
 use Zipkin\Instrumentation\Http\Server\Psr15\Propagation\RequestHeaders;
-use Zipkin\Instrumentation\Http\Server\Parser;
+use Zipkin\Instrumentation\Http\Server\HttpServerParser;
 use Zipkin\Instrumentation\Http\Server\HttpServerTracing;
 use Throwable;
 use Psr\Http\Server\RequestHandlerInterface;
@@ -34,7 +34,7 @@ final class Middleware implements MiddlewareInterface
     private $extractor;
 
     /**
-     * @var Parser
+     * @var HttpServerParser
      */
     private $parser;
 

--- a/src/Zipkin/Instrumentation/Http/Server/Psr15/Request.php
+++ b/src/Zipkin/Instrumentation/Http/Server/Psr15/Request.php
@@ -7,9 +7,6 @@ namespace Zipkin\Instrumentation\Http\Server\Psr15;
 use Zipkin\Instrumentation\Http\Server\Request as ServerRequest;
 use Psr\Http\Message\RequestInterface;
 
-/**
- * {@inheritdoc}
- */
 final class Request extends ServerRequest
 {
     /**

--- a/src/Zipkin/Instrumentation/Http/Server/Psr15/Response.php
+++ b/src/Zipkin/Instrumentation/Http/Server/Psr15/Response.php
@@ -8,9 +8,6 @@ use Zipkin\Instrumentation\Http\Server\Response as ServerResponse;
 use Zipkin\Instrumentation\Http\Server\Request as ServerRequest;
 use Psr\Http\Message\ResponseInterface;
 
-/**
- * {@inheritdoc}
- */
 final class Response extends ServerResponse
 {
     /**

--- a/src/Zipkin/Instrumentation/Http/Server/Request.php
+++ b/src/Zipkin/Instrumentation/Http/Server/Request.php
@@ -5,10 +5,8 @@ declare(strict_types=1);
 namespace Zipkin\Instrumentation\Http\Server;
 
 use Zipkin\Instrumentation\Http\Request as HttpRequest;
+use const Zipkin\Tags\HTTP_ROUTE;
 
-/**
- * {@inheritdoc}
- */
 abstract class Request extends HttpRequest
 {
     /**
@@ -21,7 +19,7 @@ abstract class Request extends HttpRequest
      * identify the route. Parsing should expect this and look at {@link HttpResponse#route()} as
      * needed.
      *
-     * @see Zipkin\Tags\HTTP_ROUTE
+     * @see HTTP_ROUTE
      */
     public function getRoute(): ?string
     {

--- a/src/Zipkin/Instrumentation/Http/Server/Response.php
+++ b/src/Zipkin/Instrumentation/Http/Server/Response.php
@@ -6,9 +6,6 @@ namespace Zipkin\Instrumentation\Http\Server;
 
 use Zipkin\Instrumentation\Http\Response as HttpResponse;
 
-/**
- * {@inheritdoc}
- */
 abstract class Response extends HttpResponse
 {
     /**

--- a/src/Zipkin/Reporters/SpanSerializer.php
+++ b/src/Zipkin/Reporters/SpanSerializer.php
@@ -14,6 +14,7 @@ interface SpanSerializer
 {
     /**
      * @param ReadbackSpan[]|array $spans
+     * @return string with spans serialized
      */
     public function serialize(array $spans): string;
 }

--- a/src/Zipkin/Span.php
+++ b/src/Zipkin/Span.php
@@ -6,6 +6,7 @@ namespace Zipkin;
 
 use Zipkin\Propagation\TraceContext;
 use Throwable;
+use const Zipkin\Kind\SERVER;
 
 interface Span
 {
@@ -44,7 +45,7 @@ interface Span
 
     /**
      * The kind of span is optional. When set, it affects how a span is reported. For example, if the
-     * kind is {@link Zipkin\Kind\SERVER}, the span's start timestamp is implicitly annotated as "sr"
+     * kind is {@link SERVER}, the span's start timestamp is implicitly annotated as "sr"
      * and that plus its duration as "ss".
      *
      * The value must be strictly one of the ones listed in {@link Kind}.
@@ -68,6 +69,7 @@ interface Span
 
     /**
      * Adds tags depending on the configured {@link Tracing::errorParser() error parser}
+     * @param Throwable $e
      */
     public function setError(Throwable $e): void;
 
@@ -75,7 +77,7 @@ interface Span
      * Associates an event that explains latency with the current system time.
      *
      * @param string $value A short tag indicating the event, like "finagle.retry"
-     * @param int $timestamp
+     * @param int|null $timestamp
      * @return void
      * @see Annotations
      */

--- a/src/Zipkin/SpanCustomizer.php
+++ b/src/Zipkin/SpanCustomizer.php
@@ -37,7 +37,7 @@ interface SpanCustomizer
      * Associates an event that explains latency with the current system time.
      *
      * @param string $value A short tag indicating the event, like "finagle.retry"
-     * @param int $timestamp
+     * @param int|null $timestamp
      * @return void
      * @see Annotations
      */

--- a/tests/Integration/Instrumentation/Http/Server/MiddlewareTest.php
+++ b/tests/Integration/Instrumentation/Http/Server/MiddlewareTest.php
@@ -13,9 +13,9 @@ use Zipkin\Propagation\TraceContext;
 
 use Zipkin\Instrumentation\Http\Server\Request;
 use Zipkin\Instrumentation\Http\Server\Psr15\Middleware;
-use Zipkin\Instrumentation\Http\Server\Parser;
+use Zipkin\Instrumentation\Http\Server\HttpServerParser;
 use Zipkin\Instrumentation\Http\Server\HttpServerTracing;
-use Zipkin\Instrumentation\Http\Server\DefaultParser;
+use Zipkin\Instrumentation\Http\Server\DefaultHttpServerParser;
 use RingCentral\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Middlewares\Utils\Factory;
@@ -25,7 +25,7 @@ use FastRoute\RouteCollector;
 
 final class MiddlewareTest extends TestCase
 {
-    private static function createTracing(Parser $parser): array
+    private static function createTracing(HttpServerParser $parser): array
     {
         $reporter = new InMemory();
         $tracing =
@@ -46,7 +46,7 @@ final class MiddlewareTest extends TestCase
 
     public function testMiddlewareRecordsRequestSuccessfully()
     {
-        $parser = new class() extends DefaultParser {
+        $parser = new class() extends DefaultHttpServerParser {
             public function request(Request $request, TraceContext $context, SpanCustomizer $span): void
             {
                 // This parser retrieves the user_id from the request and add

--- a/tests/Unit/Instrumentation/Http/Client/Psr18/ClientTest.php
+++ b/tests/Unit/Instrumentation/Http/Client/Psr18/ClientTest.php
@@ -9,7 +9,7 @@ use Zipkin\Samplers\BinarySampler;
 use Zipkin\Reporters\InMemory;
 use Zipkin\Instrumentation\Http\Client\Psr18\Client;
 use Zipkin\Instrumentation\Http\Client\HttpClientTracing;
-use Zipkin\Instrumentation\Http\Client\DefaultParser;
+use Zipkin\Instrumentation\Http\Client\DefaultHttpClientParser;
 use RuntimeException;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\RequestInterface;
@@ -31,7 +31,7 @@ final class ClientTest extends TestCase
         $tracer = $tracing->getTracer();
 
         return [
-            new HttpClientTracing($tracing, new DefaultParser),
+            new HttpClientTracing($tracing, new DefaultHttpClientParser),
             static function () use ($tracer, $reporter): array {
                 $tracer->flush();
                 return $reporter->flush();

--- a/tests/Unit/Instrumentation/Http/Server/Psr15/MiddlewareTest.php
+++ b/tests/Unit/Instrumentation/Http/Server/Psr15/MiddlewareTest.php
@@ -12,7 +12,7 @@ use Zipkin\Propagation\TraceContext;
 use Zipkin\Propagation\DefaultSamplingFlags;
 use Zipkin\Instrumentation\Http\Server\Psr15\Middleware;
 use Zipkin\Instrumentation\Http\Server\HttpServerTracing;
-use Zipkin\Instrumentation\Http\Server\DefaultParser;
+use Zipkin\Instrumentation\Http\Server\DefaultHttpServerParser;
 use RingCentral\Psr7\Response as Psr7Response;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -34,7 +34,7 @@ final class ServerTest extends TestCase
         $tracer = $tracing->getTracer();
 
         return [
-            new HttpServerTracing($tracing, new DefaultParser, $requestSampler),
+            new HttpServerTracing($tracing, new DefaultHttpServerParser, $requestSampler),
             static function () use ($tracer, $reporter): array {
                 $tracer->flush();
                 return $reporter->flush();


### PR DESCRIPTION
…asier for implementors to understand the code.