### PR TITLE
feat(json-format): lowercase span name and service name as per swagger definition

### DIFF
--- a/src/Zipkin/Reporters/JsonV2Serializer.php
+++ b/src/Zipkin/Reporters/JsonV2Serializer.php
@@ -31,9 +31,9 @@ class JsonV2Serializer implements SpanSerializer
         return '[' . implode(',', $spansAsArray) . ']';
     }
 
-    private function serializeEndpoint(Endpoint $endpoint): string
+    private static function serializeEndpoint(Endpoint $endpoint): string
     {
-        $endpointStr =  '{"serviceName":"' . $endpoint->getServiceName() . '"';
+        $endpointStr =  '{"serviceName":"' . \strtolower($endpoint->getServiceName()) . '"';
 
         if ($endpoint->getIpv4() !== null) {
             $endpointStr .= ',"ipv4":"' . $endpoint->getIpv4() . '"';
@@ -54,9 +54,12 @@ class JsonV2Serializer implements SpanSerializer
     {
         $spanStr =
             '{"id":"' . $span->getSpanId() . '"'
-            . ',"name":"' . $span->getName() . '"'
             . ',"traceId":"' . $span->getTraceId() . '"'
             . ',"timestamp":' . $span->getTimestamp();
+
+        if ($span->getName() !== null) {
+            $spanStr .= ',"name":"' . \strtolower($span->getName()) . '"';
+        }
 
         if ($span->getDuration() !== null) {
             $spanStr .= ',"duration":' . $span->getDuration();

--- a/tests/Unit/Reporters/HttpTest.php
+++ b/tests/Unit/Reporters/HttpTest.php
@@ -15,8 +15,8 @@ use PHPUnit\Framework\TestCase;
 
 final class HttpTest extends TestCase
 {
-    const PAYLOAD = '[{"id":"%s","name":"test","traceId":"%s",'
-        . '"timestamp":%d,"localEndpoint":{"serviceName":""}}]';
+    const PAYLOAD = '[{"id":"%s","traceId":"%s",'
+        . '"timestamp":%d,"name":"test","localEndpoint":{"serviceName":""}}]';
 
     public function testConstructorIsRetrocompatible()
     {

--- a/tests/Unit/Reporters/JsonV2SerializerTest.php
+++ b/tests/Unit/Reporters/JsonV2SerializerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ZipkinTests\Unit\Propagation;
+namespace ZipkinTests\Unit\Reporters;
 
 use Zipkin\Reporters\JsonV2Serializer;
 use Zipkin\Recording\Span;
@@ -17,9 +17,9 @@ final class JsonV2SerializerTest extends TestCase
         $span = Span::createFromContext($context, $localEndpoint);
         $startTime = 1594044779509687;
         $span->start($startTime);
-        $span->setName('test');
+        $span->setName('Test');
         $span->setKind('CLIENT');
-        $remoteEndpoint = Endpoint::create('service2', null, '2001:0db8:85a3:0000:0000:8a2e:0370:7334', 3302);
+        $remoteEndpoint = Endpoint::create('SERVICE2', null, '2001:0db8:85a3:0000:0000:8a2e:0370:7334', 3302);
         $span->setRemoteEndpoint($remoteEndpoint);
         $span->tag('test_key', 'test_value');
         $span->annotate($startTime + 100, 'test_annotarion');
@@ -29,7 +29,7 @@ final class JsonV2SerializerTest extends TestCase
         $serializedSpans = $serializer->serialize([$span]);
 
         $expectedSerialization = '[{'
-            . '"id":"186f11b67460db4d","name":"test","traceId":"186f11b67460db4d","timestamp":1594044779509687,'
+            . '"id":"186f11b67460db4d","traceId":"186f11b67460db4d","timestamp":1594044779509687,"name":"test",'
             . '"duration":1000,"localEndpoint":{"serviceName":"service1","ipv4":"192.168.0.11","port":3301},'
             . '"kind":"CLIENT",'
             . '"remoteEndpoint":{"serviceName":"service2","ipv6":"2001:0db8:85a3:0000:0000:8a2e:0370:7334","port":3302}'
@@ -55,7 +55,7 @@ final class JsonV2SerializerTest extends TestCase
         $serializedSpans = $serializer->serialize([$span]);
 
         $expectedSerialization = '[{'
-            . '"id":"186f11b67460db4d","name":"test","traceId":"186f11b67460db4d","timestamp":1594044779509688,'
+            . '"id":"186f11b67460db4d","traceId":"186f11b67460db4d","timestamp":1594044779509688,"name":"test",'
             . '"duration":1000,"localEndpoint":{"serviceName":"service1","ipv4":"192.168.0.11","port":3301},'
             . '"tags":{"test_key":"test_value","error":"priority_error"}'
             . '}]';


### PR DESCRIPTION
Somehow we missed that the swagger definition for the post spans endpoint was requiring the span name and the service name to be lowercase. Since this is purely zipkin json v2, we delegate this responsability to the JSON V2 Serializer.

<img width="940" alt="image" src="https://user-images.githubusercontent.com/3075074/89295804-cc8a2a00-d661-11ea-9893-f0e4fdce4d37.png">

<img width="1088" alt="image" src="https://user-images.githubusercontent.com/3075074/89295832-d7dd5580-d661-11ea-97ef-8447b4cf87cd.png">


https://zipkin.io/zipkin-api/\#/default/post_spans.

Ping @adriancole 