### PR TITLE
chore(reporting): adds b3:0 header to the reporting call to avoid tracing from mesh sidecars

### DIFF
--- a/src/Zipkin/Reporters/Http/ClientFactory.php
+++ b/src/Zipkin/Reporters/Http/ClientFactory.php
@@ -7,7 +7,16 @@ namespace Zipkin\Reporters\Http;
 interface ClientFactory
 {
     /**
-     * @param array $options
+     * @param array $options the options for HTTP call:
+     *
+     * <code>
+     * $options = [
+     *   'endpoint_url' => 'http://myzipkin:9411/api/v2/spans', // the reporting url for zipkin server
+     *   'headers'      => ['X-API-Key' => 'abc123'] // the additional headers to be included in the request
+     *   'timeout'      => 10, // the timeout for the request in seconds
+     * ];
+     * </code>
+     *
      * @return callable(string):void
      */
     public function build(array $options): callable;

--- a/src/Zipkin/Reporters/Http/CurlFactory.php
+++ b/src/Zipkin/Reporters/Http/CurlFactory.php
@@ -29,7 +29,7 @@ final class CurlFactory implements ClientFactory
     /**
      * {@inheritdoc}
      */
-    public function build(array $options = []): callable
+    public function build(array $options): callable
     {
         /**
          * @param string $payload
@@ -50,6 +50,7 @@ final class CurlFactory implements ClientFactory
             $requiredHeaders = [
                 'Content-Type' => 'application/json',
                 'Content-Length' => \strlen($payload),
+                'b3' => '0',
             ];
             $additionalHeaders = $options['headers'] ?? [];
             $headers = \array_merge($additionalHeaders, $requiredHeaders);

--- a/tests/Integration/Reporters/Http/CurlFactoryTest.php
+++ b/tests/Integration/Reporters/Http/CurlFactoryTest.php
@@ -2,12 +2,12 @@
 
 namespace ZipkinTests\Integration\Reporters\Http;
 
-use HttpTest\HttpTestServer;
-use Psr\Http\Message\RequestInterface;
-use Psr\Http\Message\ResponseInterface;
-use RuntimeException;
 use Zipkin\Reporters\Http\CurlFactory;
+use RuntimeException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\RequestInterface;
 use PHPUnit\Framework\TestCase;
+use HttpTest\HttpTestServer;
 
 /**
  * @group ignore-windows
@@ -22,6 +22,7 @@ final class CurlFactoryTest extends TestCase
             function (RequestInterface $request, ResponseInterface &$response) use ($t) {
                 $t->assertEquals('POST', $request->getMethod());
                 $t->assertEquals('application/json', $request->getHeader('Content-Type')[0]);
+                $t->assertEquals('0', $request->getHeader('b3')[0]);
                 $response = $response->withStatus(202);
             }
         );


### PR DESCRIPTION
Related to https://github.com/openzipkin/b3-propagation/pull/42#event-3760887270