### PR TITLE
feat(http): adds support for route in response object for late parsing.

### DIFF
--- a/src/Zipkin/Instrumentation/Http/Server/Psr15/Response.php
+++ b/src/Zipkin/Instrumentation/Http/Server/Psr15/Response.php
@@ -20,12 +20,19 @@ final class Response extends ServerResponse
      */
     private $request;
 
+    /**
+     * @var string|null
+     */
+    private $route;
+
     public function __construct(
         ResponseInterface $delegate,
-        ?Request $request = null
+        ?Request $request = null,
+        ?string $route = null
     ) {
         $this->delegate = $delegate;
         $this->request = $request;
+        $this->route = $route;
     }
 
     /**
@@ -42,6 +49,14 @@ final class Response extends ServerResponse
     public function getStatusCode(): int
     {
         return $this->delegate->getStatusCode();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRoute(): ?string
+    {
+        return $this->route;
     }
 
     /**

--- a/src/Zipkin/Instrumentation/Http/Server/Response.php
+++ b/src/Zipkin/Instrumentation/Http/Server/Response.php
@@ -15,4 +15,13 @@ abstract class Response extends HttpResponse
     {
         return null;
     }
+
+    /**
+     * getRoute returns the route path, sometimes known by the response time
+     * e.g. /user/{user_id}
+     */
+    public function getRoute(): ?string
+    {
+        return null;
+    }
 }

--- a/tests/Unit/Instrumentation/Http/Server/BaseResponseTest.php
+++ b/tests/Unit/Instrumentation/Http/Server/BaseResponseTest.php
@@ -21,7 +21,8 @@ abstract class BaseResponseTest extends TestCase
         int $statusCode,
         $headers = [],
         $body = null,
-        ?Request $request = null
+        ?Request $request = null,
+        ?string $route = null
     ): array;
 
     /**
@@ -37,9 +38,10 @@ abstract class BaseResponseTest extends TestCase
         /**
          * @var Response $response
          */
-        list($response, $delegateResponse) = static::createResponse(202, [], null, $request);
+        list($response, $delegateResponse, $_, $route) = static::createResponse(202, [], null, $request, "/things");
         $this->assertEquals(202, $response->getStatusCode());
         $this->assertSame($request, $response->getRequest());
         $this->assertSame($delegateResponse, $response->unwrap());
+        $this->assertSame($route, $response->getRoute());
     }
 }

--- a/tests/Unit/Instrumentation/Http/Server/Psr15/ResponseTest.php
+++ b/tests/Unit/Instrumentation/Http/Server/Psr15/ResponseTest.php
@@ -20,11 +20,12 @@ final class ResponseTest extends BaseResponseTest
         int $statusCode,
         $headers = [],
         $body = null,
-        ?Request $request = null
+        ?Request $request = null,
+        ?string $route = null
     ): array {
         $delegateResponse = new Response($statusCode);
         $response = new Psr18Response($delegateResponse, $request);
-        return [$response, $delegateResponse, $request];
+        return [$response, $delegateResponse, $request, $route];
     }
 
     /**


### PR DESCRIPTION
This PR adds support for including the route for late parsing, mostly for those frameworks where the route is not available until very late in the request/response lifecycle (e.g. symfony).

e.g. https://github.com/jcchavezs/zipkin-instrumentation-symfony/blob/master/src/ZipkinBundle/KernelListener.php#L218