### PR TITLE
fix(json-serializer): fixes the JSON serialization to escape quotes on tags

### DIFF
--- a/src/Zipkin/Reporters/JsonV2Serializer.php
+++ b/src/Zipkin/Reporters/JsonV2Serializer.php
@@ -50,6 +50,11 @@ class JsonV2Serializer implements SpanSerializer
         return $endpointStr . '}';
     }
 
+    private static function escapeQuotes(string $s): string
+    {
+        return substr(json_encode($s), 1, -1);
+    }
+
     private function serializeSpan(ReadbackSpan $span): string
     {
         $spanStr =
@@ -98,7 +103,8 @@ class JsonV2Serializer implements SpanSerializer
                 } else {
                     $spanStr .= ',';
                 }
-                $spanStr .= '{"value":"' . $annotation['value'] . '","timestamp":' . $annotation['timestamp'] . '}';
+                $spanStr .= '{"value":"' . self::escapeQuotes($annotation['value'])
+                    . '","timestamp":' . $annotation['timestamp'] . '}';
             }
             $spanStr .= ']';
         }
@@ -118,7 +124,7 @@ class JsonV2Serializer implements SpanSerializer
                 } else {
                     $spanStr .= ',';
                 }
-                $spanStr .= '"' . $key . '":"' . $value . '"';
+                $spanStr .= '"' . $key . '":"' . self::escapeQuotes($value) . '"';
             }
             $spanStr .= '}';
         }

--- a/src/Zipkin/Reporters/JsonV2Serializer.php
+++ b/src/Zipkin/Reporters/JsonV2Serializer.php
@@ -52,7 +52,8 @@ class JsonV2Serializer implements SpanSerializer
 
     private static function escapeQuotes(string $s): string
     {
-        return substr(json_encode($s), 1, -1);
+        $encodedString = json_encode($s);
+        return $encodedString ? trim($encodedString, '"') : $s;
     }
 
     private function serializeSpan(ReadbackSpan $span): string

--- a/tests/Unit/Reporters/JsonV2SerializerTest.php
+++ b/tests/Unit/Reporters/JsonV2SerializerTest.php
@@ -65,10 +65,10 @@ final class JsonV2SerializerTest extends TestCase
     public function testJSONTagsAreSerializedCorrectly()
     {
         $jsonValue = '{"name":"Kurt"}';
-        $mutilineValue = <<<EOT
+        $mutilineValue = <<<EOD
         foo
         bar
-        EOT;
+        EOD;
 
         $context = TraceContext::create('186f11b67460db4e', '186f11b67460db4e');
         $localEndpoint = Endpoint::create('service1');

--- a/tests/Unit/Reporters/JsonV2SerializerTest.php
+++ b/tests/Unit/Reporters/JsonV2SerializerTest.php
@@ -66,9 +66,9 @@ final class JsonV2SerializerTest extends TestCase
     {
         $jsonValue = '{"name":"Kurt"}';
         $mutilineValue = <<<EOD
-        foo
-        bar
-        EOD;
+foo
+bar
+EOD;
 
         $context = TraceContext::create('186f11b67460db4e', '186f11b67460db4e');
         $localEndpoint = Endpoint::create('service1');

--- a/tests/Unit/Reporters/JsonV2SerializerTest.php
+++ b/tests/Unit/Reporters/JsonV2SerializerTest.php
@@ -22,7 +22,7 @@ final class JsonV2SerializerTest extends TestCase
         $remoteEndpoint = Endpoint::create('SERVICE2', null, '2001:0db8:85a3:0000:0000:8a2e:0370:7334', 3302);
         $span->setRemoteEndpoint($remoteEndpoint);
         $span->tag('test_key', 'test_value');
-        $span->annotate($startTime + 100, 'test_annotarion');
+        $span->annotate($startTime + 100, 'test_annotation');
         $span->setError(new \RuntimeException('test_error'));
         $span->finish($startTime + 1000);
         $serializer = new JsonV2Serializer();
@@ -33,7 +33,7 @@ final class JsonV2SerializerTest extends TestCase
             . '"duration":1000,"localEndpoint":{"serviceName":"service1","ipv4":"192.168.0.11","port":3301},'
             . '"kind":"CLIENT",'
             . '"remoteEndpoint":{"serviceName":"service2","ipv6":"2001:0db8:85a3:0000:0000:8a2e:0370:7334","port":3302}'
-            . ',"annotations":[{"value":"test_annotarion","timestamp":1594044779509787}],'
+            . ',"annotations":[{"value":"test_annotation","timestamp":1594044779509787}],'
             . '"tags":{"test_key":"test_value","error":"test_error"}'
             . '}]';
         $this->assertEquals($expectedSerialization, $serializedSpans);
@@ -58,6 +58,34 @@ final class JsonV2SerializerTest extends TestCase
             . '"id":"186f11b67460db4d","traceId":"186f11b67460db4d","timestamp":1594044779509688,"name":"test",'
             . '"duration":1000,"localEndpoint":{"serviceName":"service1","ipv4":"192.168.0.11","port":3301},'
             . '"tags":{"test_key":"test_value","error":"priority_error"}'
+            . '}]';
+        $this->assertEquals($expectedSerialization, $serializedSpans);
+    }
+
+    public function testJSONTagsAreSerializedCorrectly()
+    {
+        $jsonValue = '{"name":"Kurt"}';
+        $mutilineValue = <<<EOT
+        foo
+        bar
+EOT;
+
+        $context = TraceContext::create('186f11b67460db4e', '186f11b67460db4e');
+        $localEndpoint = Endpoint::create('service1');
+        $span = Span::createFromContext($context, $localEndpoint);
+        $startTime = 1594044779509687;
+        $span->start($startTime);
+        $span->setName('Test');
+        $span->tag('test_key_1', $jsonValue);
+        $span->tag('test_key_2', $mutilineValue);
+        $span->finish($startTime + 1000);
+        $serializer = new JsonV2Serializer();
+        $serializedSpans = $serializer->serialize([$span]);
+
+        $expectedSerialization = '[{'
+            . '"id":"186f11b67460db4e","traceId":"186f11b67460db4e","timestamp":1594044779509687,"name":"test",'
+            . '"duration":1000,"localEndpoint":{"serviceName":"service1"},'
+            . '"tags":{"test_key_1":"{\"name\":\"Kurt\"}","test_key_2":"foo\nbar"}'
             . '}]';
         $this->assertEquals($expectedSerialization, $serializedSpans);
     }

--- a/tests/Unit/Reporters/JsonV2SerializerTest.php
+++ b/tests/Unit/Reporters/JsonV2SerializerTest.php
@@ -68,7 +68,7 @@ final class JsonV2SerializerTest extends TestCase
         $mutilineValue = <<<EOT
         foo
         bar
-EOT;
+        EOT;
 
         $context = TraceContext::create('186f11b67460db4e', '186f11b67460db4e');
         $localEndpoint = Endpoint::create('service1');


### PR DESCRIPTION
Currently tags aren't being escaped and serialization was failing when adding json payloads as tags or multiline values. This is specially useful when recording request/response payloads.

Ping @adriancole @kotharironak