### PR TITLE
tests: adds support for the rout e in the HTTP response.

### DIFF
--- a/tests/Unit/Instrumentation/Http/Server/BaseResponseTest.php
+++ b/tests/Unit/Instrumentation/Http/Server/BaseResponseTest.php
@@ -15,7 +15,8 @@ abstract class BaseResponseTest extends TestCase
      * - Zipkin\Instrumentation\Http\Server\Response the response being.
      * - mixed the delegated response.
      * - Zipkin\Instrumentation\Http\Server\Request the request originating
-     *   originating the response.
+     *   the response.
+     * - string the route
      */
     abstract public static function createResponse(
         int $statusCode,
@@ -24,6 +25,15 @@ abstract class BaseResponseTest extends TestCase
         ?Request $request = null,
         string $route = null
     ): array;
+
+    /**
+     * supportsRoute tells if the request implementation supports storing the
+     * route or not.
+     */
+    protected static function supportsRoute(): bool
+    {
+        return false;
+    }
 
     /**
      * @return (Request|null)[][] the
@@ -38,9 +48,19 @@ abstract class BaseResponseTest extends TestCase
         /**
          * @var Response $response
          */
-        list($response, $delegateResponse) = static::createResponse(202, [], null, $request);
+        list($response, $delegateResponse, $_, $route) = static::createResponse(
+            202, // status code
+            [], // headers
+            null, // body
+            $request, // request
+            '/users/{user_id}' //route
+        );
+
         $this->assertEquals(202, $response->getStatusCode());
         $this->assertSame($request, $response->getRequest());
         $this->assertSame($delegateResponse, $response->unwrap());
+        if (self::supportsRoute()) {
+            $this->assertSame('/users/{user_id}', $route);
+        }
     }
 }

--- a/tests/Unit/Instrumentation/Http/Server/Psr15/ResponseTest.php
+++ b/tests/Unit/Instrumentation/Http/Server/Psr15/ResponseTest.php
@@ -25,7 +25,7 @@ final class ResponseTest extends BaseResponseTest
     ): array {
         $delegateResponse = new Response($statusCode);
         $response = new Psr15Response($delegateResponse, $request);
-        return [$response, $delegateResponse, $request];
+        return [$response, $delegateResponse, $request, null];
     }
 
     /**


### PR DESCRIPTION
Currently the base test was not comparing the response route.