### PR TITLE
Improve PHPUnit fixtures and assertion

### DIFF
--- a/tests/Unit/Propagation/TraceContextTest.php
+++ b/tests/Unit/Propagation/TraceContextTest.php
@@ -24,7 +24,7 @@ final class TraceContextTest extends TestCase
 
     private $hasAtLeastOneMutation;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         /* Makes sure there is at least one mutation */
         $this->hasAtLeastOneMutation = false;

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -16,7 +16,6 @@ use Zipkin\Propagation\CurrentTraceContext;
 use Zipkin\NoopSpan;
 use Zipkin\Endpoint;
 use ZipkinTests\Unit\InSpan\Sumer;
-use Throwable;
 use Prophecy\Prophecy\ObjectProphecy;
 use PHPUnit\Framework\TestCase;
 use OutOfBoundsException;
@@ -38,7 +37,7 @@ final class TracerTest extends TestCase
      */
     private $currentTracerContext;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->reporter = $this->prophesize(Reporter::class);
         $this->sampler = $this->prophesize(Sampler::class);
@@ -308,7 +307,7 @@ final class TracerTest extends TestCase
 
         $scopeCloser = $tracer->openScope($spanForScope);
 
-        $this->assertTrue(is_callable($scopeCloser));
+        $this->assertIsCallable($scopeCloser);
     }
 
     public function spanForScopeProvider()


### PR DESCRIPTION
# Changed log

- According to the [PHPUnit doc](https://phpunit.readthedocs.io/en/7.5/fixtures.html#more-setup-than-teardown), it should be `protected function setUp(): void` method.
- Using the `assertIsCallable` to assert expected type is `callable`.