### PR TITLE
PHP 8: upgrade middlewares, phpunit and replace guzzle psr7 with nyholm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macos-latest]
-        php-versions: ["7.2", "7.3", "7.4", "8.0"]
+        php-versions: ["7.3", "7.4", "8.0"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macos-latest]
-        php-versions: ["7.1", "7.2", "7.3", "7.4"]
+        php-versions: ["7.2", "7.3", "7.4", "8.0"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -39,7 +39,7 @@ jobs:
       - name: Download php-coveralls.phar
         if: matrix.operating-system == 'ubuntu-latest'
         run: |
-          wget -c -nc --retry-connrefused --tries=0 https://github.com/satooshi/php-coveralls/releases/download/v2.4.2/php-coveralls.phar
+          wget -c -nc --retry-connrefused --tries=0 https://github.com/satooshi/php-coveralls/releases/download/v2.4.3/php-coveralls.phar
           chmod +x php-coveralls.phar
           php php-coveralls.phar --version
           mkdir -p build/logs

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.phar
 composer.lock
 /vendor/
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "issues": "https://github.com/openzipkin/zipkin-php/issues"
     },
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.3 || ^8.0",
         "ext-curl": "*",
         "psr/http-message": "~1.0",
         "psr/log": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -20,20 +20,21 @@
         "issues": "https://github.com/openzipkin/zipkin-php/issues"
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.2 || ^8.0",
         "ext-curl": "*",
         "psr/http-message": "~1.0",
         "psr/log": "^1.0"
     },
     "require-dev": {
-        "guzzlehttp/psr7": "^1.6",
+        "nyholm/psr7": "^1.4",
         "jcchavezs/httptest": "~0.2",
-        "phpstan/phpstan": "~0.12.28",
-        "phpunit/phpunit": "~7.5.20",
+        "middlewares/fast-route": "^2.0",
+        "middlewares/request-handler": "^2.0",
+        "phpspec/prophecy-phpunit": "^2.0",
+        "phpstan/phpstan": "~0.12.88",
+        "phpunit/phpunit": "~9",
         "psr/http-client": "^1.0",
         "psr/http-server-middleware": "^1.0",
-        "middlewares/fast-route": "^1.2.1",
-        "middlewares/request-handler": "^1.4.0",
         "squizlabs/php_codesniffer": "3.*"
     },
     "config": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,10 +5,10 @@ parameters:
 		- vendor/autoload.php
 	checkMissingIterableValueType: false
 	ignoreErrors:
-		-
-			# if openssl_random_pseudo_bytes we want to fail
-			message: '#Parameter \#1 \$data of function bin2hex expects string, string\|false given#'
-			path: src/Zipkin/Propagation/Id.php
+		# -
+		# 	# if openssl_random_pseudo_bytes we want to fail
+		# 	message: '#Parameter \#1 \$data of function bin2hex expects string, string\|false given#'
+		# 	path: src/Zipkin/Propagation/Id.php
 		-
 			# This is probably a mistake in the logic of PHPStan as $localEndpoint is always being overrided
 			message: '#Parameter \#1 \$localEndpoint of class Zipkin\\DefaultTracing constructor expects Zipkin\\Endpoint, Zipkin\\Endpoint\|null given#'
@@ -22,10 +22,14 @@ parameters:
 			message: '#Strict comparison using \=\=\=#'
 			path: src/Zipkin/Reporters/Http.php
 		-
+			# This avoids false positive in quirky HTTP reporter constructor
+			message: '#Parameter \#2 ...\$arrays of function array_merge expects array, array|Zipkin\Reporters\Http\ClientFactory given.#'
+			path: src/Zipkin/Reporters/Http.php
+		-
 			# If we specify a type for $fn the it is impossible to justify the casting to string or array
 			message: '#Function Zipkin\\SpanName\\generateSpanName\(\) has parameter \$fn with no typehint specified.#'
 			path: src/Zipkin/SpanName.php
-		-  
+		-
 			# In general types are desired but carrier is an special case
 			message: '#has parameter \$carrier with no typehint specified#'
 			path: src/Zipkin/*

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,14 +1,15 @@
 parameters:
 	checkGenericClassInNonGenericObjectType: false
 	treatPhpDocTypesAsCertain: false
+	reportUnmatchedIgnoredErrors: false
 	bootstrapFiles:
 		- vendor/autoload.php
 	checkMissingIterableValueType: false
 	ignoreErrors:
-		# -
-		# 	# if openssl_random_pseudo_bytes we want to fail
-		# 	message: '#Parameter \#1 \$data of function bin2hex expects string, string\|false given#'
-		# 	path: src/Zipkin/Propagation/Id.php
+		-
+			# if openssl_random_pseudo_bytes we want to fail
+			message: '#Parameter \#1 \$data of function bin2hex expects string, string\|false given#'
+			path: src/Zipkin/Propagation/Id.php
 		-
 			# This is probably a mistake in the logic of PHPStan as $localEndpoint is always being overrided
 			message: '#Parameter \#1 \$localEndpoint of class Zipkin\\DefaultTracing constructor expects Zipkin\\Endpoint, Zipkin\\Endpoint\|null given#'
@@ -22,8 +23,8 @@ parameters:
 			message: '#Strict comparison using \=\=\=#'
 			path: src/Zipkin/Reporters/Http.php
 		-
-			# This avoids false positive in quirky HTTP reporter constructor
-			message: '#Parameter \#2 ...\$arrays of function array_merge expects array, array|Zipkin\Reporters\Http\ClientFactory given.#'
+			# This avoids false positive for parameter type mismatch
+			message: '#Parameter \#2 ...\$arrays of function array_merge expects array, array|Zipkin\\Reporters\\Http\\ClientFactory given#'
 			path: src/Zipkin/Reporters/Http.php
 		-
 			# If we specify a type for $fn the it is impossible to justify the casting to string or array

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,34 +1,32 @@
-<phpunit
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-        backupGlobals="true"
-        backupStaticAttributes="false"
-        bootstrap="./vendor/autoload.php"
-        cacheTokens="false"
-        colors="false"
-        convertErrorsToExceptions="true"
-        convertNoticesToExceptions="true"
-        convertWarningsToExceptions="true"
-        forceCoversAnnotation="false"
-        printerClass="PHPUnit\TextUI\ResultPrinter"
-        processIsolation="false"
-        stopOnError="false"
-        stopOnFailure="false"
-        stopOnIncomplete="false"
-        stopOnSkipped="false"
-        stopOnRisky="false"
-        testSuiteLoaderClass="PHPUnit\Runner\StandardTestSuiteLoader"
-        timeoutForSmallTests="1"
-        timeoutForMediumTests="10"
-        timeoutForLargeTests="60"
-        verbose="false">
-		<filter>
-			<whitelist processUncoveredFilesFromWhitelist="true">
-				<directory suffix=".php">./src</directory>
-				<exclude>
-					<directory>./vendor</directory>
-					<directory>./tests</directory>
-				</exclude>
-			</whitelist>
-		</filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    backupGlobals="true"
+    backupStaticAttributes="false"
+    bootstrap="./vendor/autoload.php"
+    colors="false"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    forceCoversAnnotation="false"
+    printerClass="PHPUnit\TextUI\DefaultResultPrinter"
+    processIsolation="false"
+    stopOnError="false"
+    stopOnFailure="false"
+    stopOnIncomplete="false"
+    stopOnSkipped="false"
+    stopOnRisky="false"
+    timeoutForSmallTests="1"
+    timeoutForMediumTests="10"
+    timeoutForLargeTests="60"
+    verbose="false"
+>
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+      <directory>./tests</directory>
+    </exclude>
+  </coverage>
 </phpunit>

--- a/src/Zipkin/Instrumentation/Http/Client/Psr18/README.md
+++ b/src/Zipkin/Instrumentation/Http/Client/Psr18/README.md
@@ -16,7 +16,7 @@ In this example we use Guzzle 7 but any HTTP client supporting PSR18 clients wil
 
 ```php
 use GuzzleHttp\Client;
-use GuzzleHttp\Psr7\Request;
+use Nyholm\Psr7\Request;
 use Zipkin\Instrumentation\Http\Client\HttpClientTracing;
 use Zipkin\Instrumentation\Http\Client\Psr\Client as ZipkinClient;
 

--- a/tests/Unit/Instrumentation/Http/Client/Psr18/ClientTest.php
+++ b/tests/Unit/Instrumentation/Http/Client/Psr18/ClientTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace ZipkinTests\Unit\Instrumentation\Http\Client\Psr18;
 
+use Nyholm\Psr7\Request;
+use Nyholm\Psr7\Response;
 use Zipkin\TracingBuilder;
 use Zipkin\Samplers\BinarySampler;
 use Zipkin\Reporters\InMemory;
@@ -15,8 +17,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Client\ClientInterface;
 use PHPUnit\Framework\TestCase;
-use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\Psr7\Request;
 
 final class ClientTest extends TestCase
 {

--- a/tests/Unit/Instrumentation/Http/Client/Psr18/RequestTest.php
+++ b/tests/Unit/Instrumentation/Http/Client/Psr18/RequestTest.php
@@ -6,7 +6,7 @@ namespace ZipkinTests\Unit\Instrumentation\Http\Client\Psr18;
 
 use Zipkin\Instrumentation\Http\Client\Psr18\Request;
 use ZipkinTests\Unit\Instrumentation\Http\Client\BaseRequestTest;
-use GuzzleHttp\Psr7\Request as Psr7Request;
+use Nyholm\Psr7\Request as Psr7Request;
 
 final class RequestTest extends BaseRequestTest
 {

--- a/tests/Unit/Instrumentation/Http/Client/Psr18/ResponseTest.php
+++ b/tests/Unit/Instrumentation/Http/Client/Psr18/ResponseTest.php
@@ -8,8 +8,8 @@ use Zipkin\Instrumentation\Http\Client\Request;
 use Zipkin\Instrumentation\Http\Client\Psr18\Response as Psr18Response;
 use Zipkin\Instrumentation\Http\Client\Psr18\Request as Psr18Request;
 use ZipkinTests\Unit\Instrumentation\Http\Client\BaseResponseTest;
-use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\Psr7\Request as Psr7Request;
+use Nyholm\Psr7\Response;
+use Nyholm\Psr7\Request as Psr7Request;
 
 final class ResponseTest extends BaseResponseTest
 {

--- a/tests/Unit/Instrumentation/Http/Server/Psr15/MiddlewareTest.php
+++ b/tests/Unit/Instrumentation/Http/Server/Psr15/MiddlewareTest.php
@@ -19,9 +19,9 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\RequestInterface;
 use PHPUnit\Framework\TestCase;
-use GuzzleHttp\Psr7\ServerRequest;
+use Nyholm\Psr7\ServerRequest;
 
-final class ServerTest extends TestCase
+final class MiddlewareTest extends TestCase
 {
     private static function createTracing(callable $requestSampler = null): array
     {

--- a/tests/Unit/Instrumentation/Http/Server/Psr15/RequestTest.php
+++ b/tests/Unit/Instrumentation/Http/Server/Psr15/RequestTest.php
@@ -6,7 +6,7 @@ namespace ZipkinTests\Unit\Instrumentation\Http\Server\Psr15;
 
 use Zipkin\Instrumentation\Http\Server\Psr15\Request;
 use ZipkinTests\Unit\Instrumentation\Http\Server\BaseRequestTest;
-use GuzzleHttp\Psr7\Request as Psr7Request;
+use Nyholm\Psr7\Request as Psr7Request;
 
 final class RequestTest extends BaseRequestTest
 {

--- a/tests/Unit/Instrumentation/Http/Server/Psr15/ResponseTest.php
+++ b/tests/Unit/Instrumentation/Http/Server/Psr15/ResponseTest.php
@@ -8,8 +8,8 @@ use Zipkin\Instrumentation\Http\Server\Request;
 use Zipkin\Instrumentation\Http\Server\Psr15\Response as Psr15Response;
 use Zipkin\Instrumentation\Http\Server\Psr15\Request as Psr15Request;
 use ZipkinTests\Unit\Instrumentation\Http\Server\BaseResponseTest;
-use GuzzleHttp\Psr7\Response;
-use GuzzleHttp\Psr7\Request as Psr7Request;
+use Nyholm\Psr7\Response;
+use Nyholm\Psr7\Request as Psr7Request;
 
 final class ResponseTest extends BaseResponseTest
 {

--- a/tests/Unit/Propagation/RequestHeadersTest.php
+++ b/tests/Unit/Propagation/RequestHeadersTest.php
@@ -2,7 +2,7 @@
 
 namespace ZipkinTests\Unit\Propagation;
 
-use GuzzleHttp\Psr7\Request;
+use Nyholm\Psr7\Request;
 use PHPUnit\Framework\TestCase;
 use Zipkin\Propagation\RequestHeaders;
 

--- a/tests/Unit/Propagation/TraceContextTest.php
+++ b/tests/Unit/Propagation/TraceContextTest.php
@@ -275,7 +275,7 @@ final class TraceContextTest extends TestCase
         $this->hasAtLeastOneMutation = true;
 
         if ($value === (string) $value) {
-            $value = dechex(hexdec($value) + 1);
+            $value = dechex(intval(hexdec($value)) + 1);
         }
 
         if ($value === (bool) $value) {

--- a/tests/Unit/RealSpanTest.php
+++ b/tests/Unit/RealSpanTest.php
@@ -4,6 +4,7 @@ namespace ZipkinTests\Unit;
 
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Zipkin\Endpoint;
 use Zipkin\RealSpan;
 use Zipkin\Recorder;
@@ -13,6 +14,8 @@ use Zipkin\Propagation\TraceContext;
 
 final class RealSpanTest extends TestCase
 {
+    use ProphecyTrait;
+
     private const TEST_NAME = 'test_span';
     private const TEST_KIND = 'ab';
     private const TEST_START_TIMESTAMP = 1472470996199000;

--- a/tests/Unit/RecorderTest.php
+++ b/tests/Unit/RecorderTest.php
@@ -3,6 +3,7 @@
 namespace ZipkinTests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Zipkin\Endpoint;
 use Zipkin\Propagation\DefaultSamplingFlags;
 use Zipkin\Recorder;
@@ -12,6 +13,8 @@ use Zipkin\Propagation\TraceContext;
 
 final class RecorderTest extends TestCase
 {
+    use ProphecyTrait;
+
     public function testGetTimestampReturnsNullWhenThereIsNoSuchTraceContext()
     {
         $context = TraceContext::createAsRoot(DefaultSamplingFlags::createAsEmpty());

--- a/tests/Unit/Reporters/HttpTest.php
+++ b/tests/Unit/Reporters/HttpTest.php
@@ -12,9 +12,12 @@ use TypeError;
 use Psr\Log\LoggerInterface;
 use Prophecy\Argument;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 final class HttpTest extends TestCase
 {
+    use ProphecyTrait;
+
     const PAYLOAD = '[{"id":"%s","traceId":"%s",'
         . '"timestamp":%d,"name":"test","localEndpoint":{"serviceName":""}}]';
 

--- a/tests/Unit/TracerTest.php
+++ b/tests/Unit/TracerTest.php
@@ -19,9 +19,12 @@ use ZipkinTests\Unit\InSpan\Sumer;
 use Prophecy\Prophecy\ObjectProphecy;
 use PHPUnit\Framework\TestCase;
 use OutOfBoundsException;
+use Prophecy\PhpUnit\ProphecyTrait;
 
 final class TracerTest extends TestCase
 {
+    use ProphecyTrait;
+
     /**
      * @var ObjectProphecy|Reporter
      */


### PR DESCRIPTION
Proposal for issue #202 

- there was a bit of a snowball there with respect to aligning dependencies to work with minor PHP versions (I did not try too hard to find a way to keep 7.2 as per issue comments).
-  See https://github.com/php-http/discovery/issues/164 - guzzlehttp doesn't provide expected PSR-17 factories (there's code available ready for their v2, but that would mean dropping some stability constraints) => switched to nyholm (it claims some performance boost as well, though probably not too relevant since we're talking tests)
- some tweaks around the tests: eg `dechex()` needs an `int`, but `hexdec()` returns `int|float`, running afoul of strong type check.
- updated phpunit also due to version constraints (phpunit 8 was still complaining about running on php 8) which led to lots of warnings about prophecy having to use a trait for integration with phpunit (could ignore those I guess to aim for 7.2 compatibility), which requires `phpspec/prophecy-phpunit` which in turn requires min. 7.3
- rename class that did not conform to PSR-4 