### PR TITLE
Proposed fix for coveralls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run static check
         run: composer static-check
       - name: Run tests
-        run: composer test -- --coverage-clover=build/logs/clover.xml
+        run: composer test -- 
       - name: Upload coverage report to codecov service
         if: matrix.operating-system == 'ubuntu-latest'
         run: |

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,10 +6,10 @@ parameters:
 		- vendor/autoload.php
 	checkMissingIterableValueType: false
 	ignoreErrors:
-		# -
-		# 	# if openssl_random_pseudo_bytes we want to fail
-		# 	message: '#Parameter \#1 \$data of function bin2hex expects string, string\|false given#'
-		# 	path: src/Zipkin/Propagation/Id.php
+		-
+			# if openssl_random_pseudo_bytes we want to fail
+			message: '#Parameter \#1 \$data of function bin2hex expects string, string\|false given#'
+			path: src/Zipkin/Propagation/Id.php
 		-
 			# This is probably a mistake in the logic of PHPStan as $localEndpoint is always being overrided
 			message: '#Parameter \#1 \$localEndpoint of class Zipkin\\DefaultTracing constructor expects Zipkin\\Endpoint, Zipkin\\Endpoint\|null given#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,10 +6,10 @@ parameters:
 		- vendor/autoload.php
 	checkMissingIterableValueType: false
 	ignoreErrors:
-		-
-			# if openssl_random_pseudo_bytes we want to fail
-			message: '#Parameter \#1 \$data of function bin2hex expects string, string\|false given#'
-			path: src/Zipkin/Propagation/Id.php
+		# -
+		# 	# if openssl_random_pseudo_bytes we want to fail
+		# 	message: '#Parameter \#1 \$data of function bin2hex expects string, string\|false given#'
+		# 	path: src/Zipkin/Propagation/Id.php
 		-
 			# This is probably a mistake in the logic of PHPStan as $localEndpoint is always being overrided
 			message: '#Parameter \#1 \$localEndpoint of class Zipkin\\DefaultTracing constructor expects Zipkin\\Endpoint, Zipkin\\Endpoint\|null given#'

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,6 +21,9 @@
     verbose="false"
 >
   <coverage processUncoveredFiles="true">
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
     <include>
       <directory suffix=".php">./src</directory>
     </include>


### PR DESCRIPTION
Seems that PHPUnit 9 doesn't accept the clover path via parameter, resulting in no file generated so I've added it via PHPUnit config. The git action spec already uses xdebug 3 for coverage so this should work.