### PR TITLE
Allow different versions of psr/log for better compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^7.4 || ^8.0",
         "ext-curl": "*",
         "psr/http-message": "~1.0",
-        "psr/log": "^1.0"
+        "psr/log": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "ext-mysqli": "*",

--- a/tests/Unit/Propagation/B3Test.php
+++ b/tests/Unit/Propagation/B3Test.php
@@ -343,23 +343,10 @@ final class B3Test extends TestCase
         $carrier = [];
         $carrier[strtolower(self::TRACE_ID_NAME)] = 'xyz';
         $carrier[strtolower(self::SPAN_ID_NAME)] = 'mno';
-        $test = $this;
 
-        $logger = new class($test) implements LoggerInterface {
-            use LoggerTrait;
-
-            private $test;
-
-            public function __construct(TestCase $test)
-            {
-                $this->test = $test;
-            }
-
-            public function log($level, $message, array $context = array())
-            {
-                $this->test->assertEquals('debug', $level);
-            }
-        };
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('debug');
+        
         $getter = new Map();
         $b3Propagator = new B3($logger);
         $extractor = $b3Propagator->getExtractor($getter);


### PR DESCRIPTION
This is a follow-up to https://github.com/Vinelab/tracing-laravel/pull/37.

It would be optimal to loosen constraints on `psr/log` since consumer might lock it to a different version. 

The most notable changes between major versions of `psr/log` are basically parameter and return type declarations which is why I also had to adjust PHPUnit tests a bit since the previous stub would only work with one particular version of the contract.