### PR TITLE
Removes return type unwrap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,12 @@
     "scripts": {
         "fix-lint": "phpcbf --standard=ZEND --standard=PSR2 --ignore=*/vendor/* ./",
         "lint": "phpcs --standard=ZEND --standard=PSR2 --ignore=*/vendor/* ./",
-        "test": "phpunit tests",
+        "test": [
+            "@test-unit",
+            "@test-integration"
+        ],
+        "test-unit": "phpunit tests/Unit",
+        "test-integration": "phpunit tests/Integration",
         "static-check": "phpstan analyse src --level 8"
     },
     "suggest": {

--- a/src/Zipkin/Instrumentation/Http/Request.php
+++ b/src/Zipkin/Instrumentation/Http/Request.php
@@ -60,7 +60,7 @@ abstract class Request
     abstract public function getHeader(string $name): ?string;
 
     /**
-     * @return object|null the underlying request object or {@code null} if there is none.
+     * @return mixed the underlying request object or {@code null} if there is none.
      */
-    abstract public function unwrap(): ?object;
+    abstract public function unwrap();
 }

--- a/src/Zipkin/Instrumentation/Http/Response.php
+++ b/src/Zipkin/Instrumentation/Http/Response.php
@@ -27,7 +27,7 @@ abstract class Response
     abstract public function getStatusCode(): int;
 
     /**
-     * @return object|null the underlying response object or {@code null} if there is none.
+     * @return mixed the underlying response object or {@code null} if there is none.
      */
-    abstract public function unwrap(): ?object;
+    abstract public function unwrap();
 }


### PR DESCRIPTION
This is needed because we can't do any guarantee about the types of underlying request/response models, e.g. in PSR we would use an object but in Symfony Client it is most likely be an array (see https://github.com/symfony/contracts/blob/v2.4.0/HttpClient/HttpClientInterface.php#L86), hence removing the optional object constraint.