### PR TITLE
Fixes coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,10 @@ jobs:
       - name: Run tests
         run: composer test -- --coverage-clover=build/logs/clover.xml
       - name: Upload coverage report to codecov service
-        if: ${{ matrix.operating-system == 'ubuntu-latest' && matrix.php-versions == '8.0' }}
+        if: |
+          matrix.operating-system == 'ubuntu-latest' &&
+          matrix.php-versions == '8.0' &&
+          env.GITHUB_REPOSITORY == 'openzipkin/zipkin-php'
         run: |
           wget -c -nc --retry-connrefused --tries=0 https://github.com/satooshi/php-coveralls/releases/download/v2.4.3/php-coveralls.phar
           chmod +x php-coveralls.phar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,7 @@ jobs:
       - name: Run tests
         run: composer test -- --coverage-clover=build/logs/clover.xml
       - name: Upload coverage report to codecov service
-        if: |
-          matrix.operating-system == 'ubuntu-latest' &&
-          matrix.php-versions == '8.0' &&
-          env.GITHUB_REPOSITORY == 'openzipkin/zipkin-php'
+        if: ${{ matrix.operating-system == 'ubuntu-latest' && matrix.php-versions == '8.0' }}
         run: |
           wget -c -nc --retry-connrefused --tries=0 https://github.com/satooshi/php-coveralls/releases/download/v2.4.3/php-coveralls.phar
           chmod +x php-coveralls.phar

--- a/composer.json
+++ b/composer.json
@@ -66,10 +66,7 @@
     "scripts": {
         "fix-lint": "phpcbf --standard=ZEND --standard=PSR2 --ignore=*/vendor/* ./",
         "lint": "phpcs --standard=ZEND --standard=PSR2 --ignore=*/vendor/* ./",
-        "test": [
-            "@test-unit",
-            "@test-integration"
-        ],
+        "test": "phpunit tests/Unit",
         "test-unit": "phpunit tests/Unit",
         "test-integration": "phpunit tests/Integration",
         "static-check": "phpstan analyse src --level 8"

--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
     "scripts": {
         "fix-lint": "phpcbf --standard=ZEND --standard=PSR2 --ignore=*/vendor/* ./",
         "lint": "phpcs --standard=ZEND --standard=PSR2 --ignore=*/vendor/* ./",
-        "test": "phpunit tests/Unit",
+        "test": "phpunit tests",
         "test-unit": "phpunit tests/Unit",
         "test-integration": "phpunit tests/Integration",
         "static-check": "phpstan analyse src --level 8"

--- a/src/Zipkin/Instrumentation/Mysqli/Mysqli.php
+++ b/src/Zipkin/Instrumentation/Mysqli/Mysqli.php
@@ -3,12 +3,12 @@
 namespace Zipkin\Instrumentation\Mysqli;
 
 use mysqli_result;
+use const Zipkin\Tags\ERROR;
 use Zipkin\Tracer;
 use Zipkin\Span;
-use Zipkin\Endpoint;
 
+use Zipkin\Endpoint;
 use InvalidArgumentException;
-use const Zipkin\Tags\ERROR;
 
 /**
  * Mysqli is an instrumented extension for Mysqli.

--- a/tests/Integration/Instrumentation/Mysqli/MysqliTest.php
+++ b/tests/Integration/Instrumentation/Mysqli/MysqliTest.php
@@ -21,10 +21,12 @@ final class MysqliTest extends TestCase
     {
         shell_exec('docker rm -f zipkin_php_mysql_test');
         shell_exec(sprintf('cd %s; docker-compose up -d', __DIR__));
-        echo "Waiting for mysql container to be up.";
+        echo "Waiting for MySQL container to be up.\n";
         while (true) {
             $res = shell_exec('docker ps --filter "name=zipkin_php_mysql_test" --format "{{.Status}}"');
-            if (strpos($res, "healthy") >= 0) {
+            usleep(500000);
+            if (strpos($res, "healthy") !== false) {
+                echo "MySQL container is up.\n";
                 break;
             }
         }


### PR DESCRIPTION
This PR fixes the coverage value as currently it is misleading.

The reason for this coverage value is that we were running 
```
 "test": [
            "@test-unit",
            "@test-integration"
        ],
```

So first target `test-unit` generated a report and then `test-integration` was overriding it and hence giving a false value.