### PR TITLE
 Zipkin\\RealSpan::tag() must be of the type string

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ class TraceClient implements ClientInterface
 
         try {
             $response = $this->client->request($method, $uri, $options);
-            $span->tag(Tags\HTTP_STATUS_CODE, $response->getStatusCode());
+            $span->tag(Tags\HTTP_STATUS_CODE, (string) $response->getStatusCode());
 
             return $response;
         catch (Throwable $e) {


### PR DESCRIPTION
```
Argument 2 passed to Zipkin\\RealSpan::tag() must be of the type string, int given
```